### PR TITLE
feat: 일정 검증과 슬롯 순서 저장 API 추가

### DIFF
--- a/src/main/kotlin/com/tripsync/application/persona/PersonaValidationService.kt
+++ b/src/main/kotlin/com/tripsync/application/persona/PersonaValidationService.kt
@@ -1,9 +1,8 @@
 package com.tripsync.application.persona
 
-import com.tripsync.application.consensus.ConsensusService
-import com.tripsync.application.consensus.ScheduleOptionDraft
 import com.tripsync.domain.entity.AxisScores
-import com.tripsync.domain.entity.User
+import com.tripsync.domain.enums.ScheduleOptionType
+import com.tripsync.domain.enums.SlotType
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 
@@ -36,37 +35,58 @@ class PersonaValidationService(
         val scores: AxisScores,
     )
 
+    data class ScheduleOptionForValidation(
+        val optionType: ScheduleOptionType,
+        val groupSatisfaction: Int,
+        val slots: List<ScheduleSlotForValidation>,
+        val satisfactionByUser: List<SatisfactionForValidation>,
+    )
+
+    data class ScheduleSlotForValidation(
+        val slotType: SlotType,
+        val reasonText: String,
+        val scores: AxisScores,
+    )
+
+    data class SatisfactionForValidation(
+        val userId: Long,
+        val score: Int,
+    )
+
     fun validateOptions(
-        options: List<ScheduleOptionDraft>,
+        options: List<ScheduleOptionForValidation>,
         members: List<MemberSnapshot>,
-    ): Map<com.tripsync.domain.enums.ScheduleOptionType, ValidationResult> {
+    ): Map<ScheduleOptionType, ValidationResult> {
         val start = System.currentTimeMillis()
 
         val allMatchedPersonas = members.flatMap { member ->
             personaVectorService.matchForMember(member.scores, topK = 3)
         }.distinctBy { it.uuid }
 
+        if (allMatchedPersonas.isEmpty()) {
+            logger.info { "No persona matches available for ${members.size} members in ${System.currentTimeMillis() - start}ms" }
+            return emptyMap()
+        }
+
         logger.info { "Matched ${allMatchedPersonas.size} unique personas for ${members.size} members in ${System.currentTimeMillis() - start}ms" }
 
         return options.associate { option ->
             val slotScores = option.slots.map { slot ->
-                val slotVector = AxisScores(
-                    mobility = slot.placeId.toInt() % 100,
-                    photo = slot.placeId.toInt() % 100,
-                    budget = slot.placeId.toInt() % 100,
-                    theme = slot.placeId.toInt() % 100,
-                )
                 val avgMatch = allMatchedPersonas.map { persona ->
-                    1.0 - (slotVector.l1Distance(persona.scores) / 400.0)
+                    1.0 - (slot.scores.l1Distance(persona.scores) / 400.0)
                 }.average()
                 avgMatch
             }
 
-            val acceptanceScore = (slotScores.average() * 100).toInt().coerceIn(0, 100)
+            val acceptanceScore = if (slotScores.isEmpty()) {
+                0
+            } else {
+                (slotScores.average() * 100).toInt().coerceIn(0, 100)
+            }
 
             val positiveSignals = buildPositiveSignals(option, members)
             val objections = buildObjections(option, members)
-            val persuasions = buildPersuasionPoints(option, members)
+            val persuasions = buildPersuasionPoints(option)
 
             option.optionType to ValidationResult(
                 personaAcceptanceScore = acceptanceScore,
@@ -87,14 +107,14 @@ class PersonaValidationService(
         }
     }
 
-    private fun buildPositiveSignals(option: ScheduleOptionDraft, members: List<MemberSnapshot>): List<String> {
+    private fun buildPositiveSignals(option: ScheduleOptionForValidation, members: List<MemberSnapshot>): List<String> {
         return listOf(
-            "${members.size}명의 취향이 ${option.slots.count { it.slotType == com.tripsync.domain.enums.SlotType.COMMON }}개 공통 슬롯에서 조화를 이룹니다.",
+            "${members.size}명의 취향이 ${option.slots.count { it.slotType == SlotType.COMMON }}개 공통 슬롯에서 조화를 이룹니다.",
             "그룹 만족도 ${option.groupSatisfaction}점으로 안정적인 선택입니다.",
         )
     }
 
-    private fun buildObjections(option: ScheduleOptionDraft, members: List<MemberSnapshot>): List<String> {
+    private fun buildObjections(option: ScheduleOptionForValidation, members: List<MemberSnapshot>): List<String> {
         val lowSatisfaction = option.satisfactionByUser.filter { it.score < 60 }
         return lowSatisfaction.map {
             val member = members.find { m -> m.userId == it.userId }
@@ -102,9 +122,9 @@ class PersonaValidationService(
         }
     }
 
-    private fun buildPersuasionPoints(option: ScheduleOptionDraft, members: List<MemberSnapshot>): List<String> {
-        return option.slots.filter { it.slotType == com.tripsync.domain.enums.SlotType.PERSONAL }.map { slot ->
-            "${slot.reasonText}로 개인 취향을 반영하여 갈등을 최소화했습니다."
+    private fun buildPersuasionPoints(option: ScheduleOptionForValidation): List<String> {
+        return option.slots.filter { it.slotType == SlotType.PERSONAL }.map { slot ->
+            slot.reasonText.trim().trimEnd('.', '!', '?', '。')
         }.distinct()
     }
 }

--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
@@ -1,6 +1,7 @@
 package com.tripsync.application.schedule
 
 import com.tripsync.application.consensus.*
+import com.tripsync.application.persona.PersonaValidationService
 import com.tripsync.common.dto.ApiResponse
 import com.tripsync.common.exception.DomainException
 import com.tripsync.domain.entity.*
@@ -11,6 +12,7 @@ import com.tripsync.domain.repository.*
 import com.tripsync.web.dto.GenerateScheduleDto
 import com.tripsync.web.dto.RegenerateScheduleDto
 import kotlinx.coroutines.runBlocking
+import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -26,7 +28,9 @@ class ScheduleService(
     private val placeRepository: PlaceRepository,
     private val userRepository: UserRepository,
     private val consensusService: ConsensusService,
+    private val personaValidationService: PersonaValidationService,
 ) {
+    private val logger = KotlinLogging.logger {}
 
     @Transactional
     fun generateSchedule(roomId: Long, hostId: Long, dto: GenerateScheduleDto): ApiResponse<Map<String, Any?>> {
@@ -79,17 +83,28 @@ class ScheduleService(
         )
 
         val options = runBlocking { consensusService.buildScheduleOptions(context) }
+        val placesById = places.associateBy { it.id }
+        val personaValidationByType = safePersonaValidationByType(options, members, placesById)
         val version = (scheduleRepository.findTopByRoomIdAndDelYnOrderByVersionDesc(room.id, YnFlag.N)?.version ?: 0) + 1
-        val saved = options.map { option -> saveScheduleOption(room, version, dto, option) }
+        val saved = options.map { option ->
+            saveScheduleOption(room, version, dto, option, personaValidationByType[option.optionType])
+        }
         room.status = TripRoomStatus.COMPLETED
 
         val memberNicknames = members.associate { it.userId to it.nickname }
-        val placesById = places.associateBy { it.id }
         return ApiResponse.ok(
             mapOf(
                 "roomId" to roomId,
                 "version" to version,
-                "options" to saved.map { (schedule, option) -> formatGeneratedOption(schedule.id, option, memberNicknames, placesById) },
+                "options" to saved.map { (schedule, option) ->
+                    formatGeneratedOption(
+                        scheduleId = schedule.id,
+                        option = option,
+                        personaValidation = schedule.personaValidation,
+                        memberNicknames = memberNicknames,
+                        placesById = placesById,
+                    )
+                },
             )
         )
     }
@@ -98,6 +113,25 @@ class ScheduleService(
     fun getSchedule(scheduleId: Long, userId: Long): ApiResponse<Map<String, Any?>> {
         val schedule = getActiveSchedule(scheduleId)
         validateRoomMember(schedule.room.id, userId)
+        return ApiResponse.ok(formatStoredSchedule(schedule))
+    }
+
+    @Transactional
+    fun reorderScheduleSlots(scheduleId: Long, userId: Long, slotIds: List<Long>): ApiResponse<Map<String, Any?>> {
+        val schedule = getActiveSchedule(scheduleId)
+        validateHost(schedule.room.id, userId)
+
+        val slots = scheduleSlotRepository.findAllByScheduleIdAndDelYn(schedule.id, YnFlag.N)
+        val slotsById = slots.associateBy { it.id }
+        val uniqueSlotIds = slotIds.distinct()
+        if (uniqueSlotIds.size != slotIds.size || uniqueSlotIds.size != slots.size || uniqueSlotIds.any { slotsById[it] == null }) {
+            throw DomainException(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "일정에 포함된 모든 슬롯 ID를 중복 없이 전달해야 합니다.")
+        }
+
+        uniqueSlotIds.forEachIndexed { index, slotId ->
+            slotsById.getValue(slotId).orderIndex = index + 1
+        }
+
         return ApiResponse.ok(formatStoredSchedule(schedule))
     }
 
@@ -164,6 +198,7 @@ class ScheduleService(
         version: Int,
         dto: GenerateScheduleDto,
         option: ScheduleOptionDraft,
+        personaValidation: Map<String, Any>?,
     ): Pair<Schedule, ScheduleOptionDraft> {
         val schedule = scheduleRepository.save(
             Schedule(
@@ -178,6 +213,7 @@ class ScheduleService(
                 ),
                 summary = option.summary,
                 groupSatisfaction = option.groupSatisfaction,
+                personaValidation = personaValidation,
                 llmProvider = option.llmProvider,
             )
         )
@@ -223,6 +259,7 @@ class ScheduleService(
     private fun formatGeneratedOption(
         scheduleId: Long,
         option: ScheduleOptionDraft,
+        personaValidation: Map<String, Any>?,
         memberNicknames: Map<Long, String>,
         placesById: Map<Long, Place>,
     ): Map<String, Any?> = mapOf(
@@ -231,12 +268,14 @@ class ScheduleService(
         "label" to option.label,
         "summary" to option.summary,
         "groupSatisfaction" to option.groupSatisfaction,
+        "personaValidation" to personaValidation,
         "llmProvider" to option.llmProvider,
         "llmLatencyMs" to option.llmLatencyMs,
         "fallbackUsed" to option.fallbackUsed,
-        "slots" to option.slots.sortedBy { it.orderIndex }.map { slot ->
+                "slots" to option.slots.sortedBy { it.orderIndex }.map { slot ->
             val place = placesById[slot.placeId]
             mapOf(
+                "slotId" to null,
                 "orderIndex" to slot.orderIndex,
                 "startTime" to slot.startTime.toString(),
                 "endTime" to slot.endTime.toString(),
@@ -273,6 +312,7 @@ class ScheduleService(
             "personaValidation" to schedule.personaValidation,
             "slots" to schedule.slots.filter { it.delYn == YnFlag.N }.sortedBy { it.orderIndex }.map { slot ->
                 mapOf(
+                    "slotId" to slot.id,
                     "orderIndex" to slot.orderIndex,
                     "startTime" to slot.startTime.toString(),
                     "endTime" to slot.endTime.toString(),
@@ -303,6 +343,80 @@ class ScheduleService(
         "longitude" to place?.longitude?.toDouble(),
         "isDepopulationArea" to isDepopulationArea(place?.metadataTags),
     )
+
+    private fun safePersonaValidationByType(
+        options: List<ScheduleOptionDraft>,
+        members: List<MemberSnapshot>,
+        placesById: Map<Long, Place>,
+    ): Map<ScheduleOptionType, Map<String, Any>> {
+        return try {
+            val personaMembers = members.map {
+                PersonaValidationService.MemberSnapshot(
+                    userId = it.userId,
+                    scores = it.scores,
+                )
+            }
+            val validationOptions = options.map { option ->
+                PersonaValidationService.ScheduleOptionForValidation(
+                    optionType = option.optionType,
+                    groupSatisfaction = option.groupSatisfaction,
+                    slots = option.slots.map { slot ->
+                        val place = placesById[slot.placeId]
+                            ?: throw DomainException(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소를 찾을 수 없습니다.")
+                        PersonaValidationService.ScheduleSlotForValidation(
+                            slotType = slot.slotType,
+                            reasonText = slot.reasonText,
+                            scores = AxisScores(
+                                mobility = place.mobilityScore,
+                                photo = place.photoScore,
+                                budget = place.budgetScore,
+                                theme = place.themeScore,
+                            ),
+                        )
+                    },
+                    satisfactionByUser = option.satisfactionByUser.map {
+                        PersonaValidationService.SatisfactionForValidation(
+                            userId = it.userId,
+                            score = it.score,
+                        )
+                    },
+                )
+            }
+
+            personaValidationService.validateOptions(validationOptions, personaMembers)
+                .filterValues { it.matchedPersonaCount > 0 }
+                .mapValues { (_, result) -> result.toPersonaValidationMap() }
+        } catch (error: Exception) {
+            logger.warn(error) { "Persona validation failed. Schedule generation will continue with personaValidation=null." }
+            emptyMap()
+        }
+    }
+
+    private fun PersonaValidationService.ValidationResult.toPersonaValidationMap(): Map<String, Any> {
+        return mapOf(
+            "source" to source,
+            "dataset" to dataset,
+            "summary" to "비슷한 여행자 참고군 ${matchedPersonaCount}명 기준 수용도 ${personaAcceptanceScore}점",
+            "personaAcceptanceScore" to personaAcceptanceScore,
+            "matchedPersonaCount" to matchedPersonaCount,
+            "matchedPersonas" to matchedPersonas.map { persona ->
+                mapOf(
+                    "matchedUserId" to persona.matchedUserId,
+                    "similarity" to persona.similarity,
+                    "personaSummary" to persona.personaSummary,
+                    "scores" to mapOf(
+                        "mobility" to persona.scores.mobility,
+                        "photo" to persona.scores.photo,
+                        "budget" to persona.scores.budget,
+                        "theme" to persona.scores.theme,
+                    ),
+                )
+            },
+            "topPositiveSignals" to topPositiveSignals,
+            "objectionReasons" to objectionReasons,
+            "persuasionPoints" to persuasionPoints,
+        )
+    }
 
     private fun isDepopulationArea(metadataTags: Map<String, Any>?): Boolean {
         return metadataTags?.get("populationDeclineArea") == true || metadataTags?.get("regionType") == "population_decline"

--- a/src/main/kotlin/com/tripsync/domain/repository/ScheduleSlotRepository.kt
+++ b/src/main/kotlin/com/tripsync/domain/repository/ScheduleSlotRepository.kt
@@ -1,8 +1,11 @@
 package com.tripsync.domain.repository
 
 import com.tripsync.domain.entity.ScheduleSlot
+import com.tripsync.domain.enums.YnFlag
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ScheduleSlotRepository : JpaRepository<ScheduleSlot, Long>
+interface ScheduleSlotRepository : JpaRepository<ScheduleSlot, Long> {
+    fun findAllByScheduleIdAndDelYn(scheduleId: Long, delYn: YnFlag): List<ScheduleSlot>
+}

--- a/src/main/kotlin/com/tripsync/infrastructure/tourapi/TourApiClient.kt
+++ b/src/main/kotlin/com/tripsync/infrastructure/tourapi/TourApiClient.kt
@@ -90,9 +90,12 @@ class TourApiClient(
 
     private fun parsePlaces(response: String): List<Place> {
         val root = objectMapper.readTree(response)
-        val items = root.path("response").path("body").path("items").path("item")
-
-        if (!items.isArray) return emptyList()
+        val itemNode = root.path("response").path("body").path("items").path("item")
+        val items = when {
+            itemNode.isArray -> itemNode.toList()
+            itemNode.isObject -> listOf(itemNode)
+            else -> emptyList()
+        }
 
         return items.mapNotNull { item ->
             try {

--- a/src/main/kotlin/com/tripsync/web/dto/AuthDto.kt
+++ b/src/main/kotlin/com/tripsync/web/dto/AuthDto.kt
@@ -115,3 +115,8 @@ data class RegenerateScheduleDto(
     val tripEndDate: String? = null,
     val reason: String? = null,
 )
+
+data class ReorderScheduleSlotsDto(
+    @field:NotEmpty
+    val slotIds: List<Long>,
+)

--- a/src/main/kotlin/com/tripsync/web/schedule/ScheduleController.kt
+++ b/src/main/kotlin/com/tripsync/web/schedule/ScheduleController.kt
@@ -7,6 +7,7 @@ import com.tripsync.common.exception.DomainException
 import com.tripsync.web.dto.ConfirmScheduleDto
 import com.tripsync.web.dto.GenerateScheduleDto
 import com.tripsync.web.dto.RegenerateScheduleDto
+import com.tripsync.web.dto.ReorderScheduleSlotsDto
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.context.SecurityContextHolder
@@ -46,6 +47,14 @@ class ScheduleController(
     @GetMapping("/schedules/{scheduleId}")
     fun getSchedule(@PathVariable scheduleId: Long): ApiResponse<Map<String, Any?>> {
         return scheduleService.getSchedule(scheduleId, currentUser().id)
+    }
+
+    @PatchMapping("/schedules/{scheduleId}/slots/order")
+    fun reorderScheduleSlots(
+        @PathVariable scheduleId: Long,
+        @Valid @RequestBody dto: ReorderScheduleSlotsDto,
+    ): ApiResponse<Map<String, Any?>> {
+        return scheduleService.reorderScheduleSlots(scheduleId, currentUser().id, dto.slotIds)
     }
 
     @PostMapping("/schedules/{scheduleId}/regenerate")

--- a/src/test/kotlin/com/tripsync/application/persona/PersonaValidationServiceTest.kt
+++ b/src/test/kotlin/com/tripsync/application/persona/PersonaValidationServiceTest.kt
@@ -1,0 +1,86 @@
+package com.tripsync.application.persona
+
+import com.tripsync.domain.entity.AxisScores
+import com.tripsync.domain.enums.ScheduleOptionType
+import com.tripsync.domain.enums.SlotType
+import com.tripsync.domain.repository.PersonaVectorRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.util.UUID
+
+class PersonaValidationServiceTest {
+
+    @Test
+    fun `validation uses real slot axis scores instead of place id derived placeholders`() {
+        val vectorService = personaVectorServiceWith(
+            PersonaVectorService.PersonaVectorData(
+                uuid = UUID.randomUUID(),
+                scores = AxisScores(mobility = 90, photo = 80, budget = 70, theme = 60),
+                summary = "활동적인 참고군",
+            )
+        )
+        val service = PersonaValidationService(vectorService)
+
+        val result = service.validateOptions(
+            options = listOf(
+                optionWithSlotScores(AxisScores(mobility = 90, photo = 80, budget = 70, theme = 60)),
+            ),
+            members = listOf(
+                PersonaValidationService.MemberSnapshot(
+                    userId = 1L,
+                    scores = AxisScores(mobility = 90, photo = 80, budget = 70, theme = 60),
+                )
+            ),
+        )[ScheduleOptionType.BALANCED]!!
+
+        assertEquals(100, result.personaAcceptanceScore)
+        assertEquals(1, result.matchedPersonaCount)
+    }
+
+    @Test
+    fun `validation returns empty map when no persona matches are available`() {
+        val service = PersonaValidationService(personaVectorServiceWith())
+
+        val result = service.validateOptions(
+            options = listOf(optionWithSlotScores(AxisScores(mobility = 10, photo = 20, budget = 30, theme = 40))),
+            members = listOf(
+                PersonaValidationService.MemberSnapshot(
+                    userId = 1L,
+                    scores = AxisScores(mobility = 10, photo = 20, budget = 30, theme = 40),
+                )
+            ),
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    private fun optionWithSlotScores(scores: AxisScores): PersonaValidationService.ScheduleOptionForValidation {
+        return PersonaValidationService.ScheduleOptionForValidation(
+            optionType = ScheduleOptionType.BALANCED,
+            groupSatisfaction = 80,
+            slots = listOf(
+                PersonaValidationService.ScheduleSlotForValidation(
+                    slotType = SlotType.COMMON,
+                    reasonText = "그룹 전원의 평균 취향 반영",
+                    scores = scores,
+                )
+            ),
+            satisfactionByUser = listOf(
+                PersonaValidationService.SatisfactionForValidation(userId = 1L, score = 80),
+            ),
+        )
+    }
+
+    private fun personaVectorServiceWith(
+        vararg vectors: PersonaVectorService.PersonaVectorData,
+    ): PersonaVectorService {
+        val repository = Mockito.mock(PersonaVectorRepository::class.java)
+        val service = PersonaVectorService(repository)
+        val field = PersonaVectorService::class.java.getDeclaredField("vectorPool")
+        field.isAccessible = true
+        field.set(service, vectors.toList())
+        return service
+    }
+}


### PR DESCRIPTION
## 변경 사항
- persona 검증 결과 생성 로직을 실제 장소 축 점수 기반으로 보정
- 확정 일정 슬롯 순서 저장 API 추가
- TourAPI 응답 파싱 구조 보정
- persona 검증 회귀 테스트 추가

## 검증
- ./gradlew test
- Docker 환경에서 슬롯 순서 저장 API 실제 호출 확인
