### PR TITLE
feat: 내 여행방 목록 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/tripsync/application/room/RoomService.kt
+++ b/src/main/kotlin/com/tripsync/application/room/RoomService.kt
@@ -73,6 +73,25 @@ class RoomService(
     }
 
     @Transactional(readOnly = true)
+    fun getMyRooms(user: User): ApiResponse<Map<String, Any>> {
+        if (user.isGuest) {
+            throw DomainException(HttpStatus.FORBIDDEN, "FORBIDDEN", "방장 계정으로 로그인해주세요.")
+        }
+
+        val rooms = roomMemberRepository.findAllByUserIdAndDelYn(user.id, YnFlag.N)
+            .map { it.room }
+            .filter { it.delYn == YnFlag.N }
+            .distinctBy { it.id }
+            .sortedWith(compareByDescending<TripRoom> { it.createdAt }.thenByDescending { it.id })
+            .map { room ->
+                val memberCount = roomMemberRepository.findAllByRoomIdAndDelYn(room.id, YnFlag.N).size
+                roomSummary(room, memberCount)
+            }
+
+        return ApiResponse.ok(mapOf("rooms" to rooms))
+    }
+
+    @Transactional(readOnly = true)
     fun getShareRoom(shareCode: String): ApiResponse<Map<String, Any>> {
         val room = tripRoomRepository.findByShareCodeAndDelYn(shareCode, YnFlag.N)
             ?: throw DomainException(HttpStatus.NOT_FOUND, "INVALID_SHARE_CODE", "유효하지 않은 공유 코드입니다.")

--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
@@ -16,6 +16,9 @@ import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneId
 
 @Service
 class ScheduleService(
@@ -113,6 +116,82 @@ class ScheduleService(
     fun getSchedule(scheduleId: Long, userId: Long): ApiResponse<Map<String, Any?>> {
         val schedule = getActiveSchedule(scheduleId)
         validateRoomMember(schedule.room.id, userId)
+        return ApiResponse.ok(formatStoredSchedule(schedule))
+    }
+
+
+    @Transactional(readOnly = true)
+    fun searchPlacesForSchedule(scheduleId: Long, userId: Long, query: String): ApiResponse<Map<String, Any?>> {
+        val schedule = getActiveSchedule(scheduleId)
+        validateHost(schedule.room.id, userId)
+
+        val normalizedQuery = query.trim().lowercase()
+        val usedPlaceIds = scheduleSlotRepository.findAllByScheduleIdAndDelYn(schedule.id, YnFlag.N)
+            .map { it.place.id }
+            .toSet()
+        val places = placeRepository.findByDelYn(YnFlag.N)
+            .asSequence()
+            .filter { place ->
+                normalizedQuery.isBlank() ||
+                    place.name.lowercase().contains(normalizedQuery) ||
+                    place.address.lowercase().contains(normalizedQuery) ||
+                    place.category.lowercase().contains(normalizedQuery)
+            }
+            .sortedWith(
+                compareByDescending<Place> { isDepopulationArea(it.metadataTags) }
+                    .thenBy { it.name }
+            )
+            .take(30)
+            .map { place ->
+                formatPlace(place, place.id, place.name, place.address) + mapOf(
+                    "alreadyAdded" to usedPlaceIds.contains(place.id),
+                )
+            }
+            .toList()
+
+        return ApiResponse.ok(
+            mapOf(
+                "places" to places,
+                "query" to query.trim(),
+            )
+        )
+    }
+
+    @Transactional
+    fun addScheduleSlot(scheduleId: Long, userId: Long, placeId: Long): ApiResponse<Map<String, Any?>> {
+        val schedule = getActiveSchedule(scheduleId)
+        validateHost(schedule.room.id, userId)
+
+        val place = placeRepository.findById(placeId)
+            .orElseThrow { DomainException(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소를 찾을 수 없습니다.") }
+        if (place.delYn != YnFlag.N) {
+            throw DomainException(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소를 찾을 수 없습니다.")
+        }
+
+        val slots = scheduleSlotRepository.findAllByScheduleIdAndDelYn(schedule.id, YnFlag.N)
+        if (slots.any { it.place.id == place.id }) {
+            throw DomainException(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "이미 일정에 포함된 장소입니다.")
+        }
+
+        val orderedSlots = slots.sortedBy { it.orderIndex }
+        val nextOrderIndex = (orderedSlots.maxOfOrNull { it.orderIndex } ?: 0) + 1
+        val startTime = orderedSlots.maxByOrNull { it.orderIndex }?.endTime ?: defaultSlotStart(schedule)
+        val endTime = startTime.plus(Duration.ofHours(2))
+
+        scheduleSlotRepository.save(
+            ScheduleSlot(
+                schedule = schedule,
+                startTime = startTime,
+                endTime = endTime,
+                place = place,
+                slotType = com.tripsync.domain.enums.SlotType.COMMON,
+                targetUser = null,
+                reasonAxis = com.tripsync.domain.enums.ReasonAxis.COMMON,
+                reasonText = "직접 추가한 장소입니다.",
+                orderIndex = nextOrderIndex,
+            )
+        )
+
         return ApiResponse.ok(formatStoredSchedule(schedule))
     }
 
@@ -284,6 +363,7 @@ class ScheduleService(
                 "targetNickname" to slot.targetUserId?.let { memberNicknames[it] },
                 "reasonAxis" to slot.reasonAxis.name.lowercase(),
                 "reasonText" to slot.reasonText,
+                "reason" to slot.reasonText,
                 "place" to formatPlace(place, slot.placeId, slot.placeName, slot.placeAddress),
             )
         },
@@ -321,6 +401,7 @@ class ScheduleService(
                     "targetNickname" to slot.targetUser?.id?.let { memberNicknames[it] },
                     "reasonAxis" to slot.reasonAxis.name.lowercase(),
                     "reasonText" to slot.reasonText,
+                    "reason" to slot.reasonText,
                     "place" to formatPlace(slot.place, slot.place.id, slot.place.name, slot.place.address),
                 )
             },
@@ -416,6 +497,14 @@ class ScheduleService(
             "objectionReasons" to objectionReasons,
             "persuasionPoints" to persuasionPoints,
         )
+    }
+
+
+    private fun defaultSlotStart(schedule: Schedule): java.time.Instant {
+        return LocalDate.parse(schedule.room.tripDate.toString())
+            .atTime(9, 0)
+            .atZone(ZoneId.of("Asia/Seoul"))
+            .toInstant()
     }
 
     private fun isDepopulationArea(metadataTags: Map<String, Any>?): Boolean {

--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
@@ -124,6 +124,7 @@ class ScheduleService(
     fun searchPlacesForSchedule(scheduleId: Long, userId: Long, query: String): ApiResponse<Map<String, Any?>> {
         val schedule = getActiveSchedule(scheduleId)
         validateHost(schedule.room.id, userId)
+        validateConfirmedSchedule(schedule)
 
         val normalizedQuery = query.trim().lowercase()
         val usedPlaceIds = scheduleSlotRepository.findAllByScheduleIdAndDelYn(schedule.id, YnFlag.N)
@@ -161,6 +162,7 @@ class ScheduleService(
     fun addScheduleSlot(scheduleId: Long, userId: Long, placeId: Long): ApiResponse<Map<String, Any?>> {
         val schedule = getActiveSchedule(scheduleId)
         validateHost(schedule.room.id, userId)
+        validateConfirmedSchedule(schedule)
 
         val place = placeRepository.findById(placeId)
             .orElseThrow { DomainException(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소를 찾을 수 없습니다.") }
@@ -178,7 +180,7 @@ class ScheduleService(
         val startTime = orderedSlots.maxByOrNull { it.orderIndex }?.endTime ?: defaultSlotStart(schedule)
         val endTime = startTime.plus(Duration.ofHours(2))
 
-        scheduleSlotRepository.save(
+        val newSlot = scheduleSlotRepository.save(
             ScheduleSlot(
                 schedule = schedule,
                 startTime = startTime,
@@ -191,6 +193,7 @@ class ScheduleService(
                 orderIndex = nextOrderIndex,
             )
         )
+        redistributeSlotsWithinScheduleWindow(schedule, orderedSlots + newSlot)
 
         return ApiResponse.ok(formatStoredSchedule(schedule))
     }
@@ -500,11 +503,58 @@ class ScheduleService(
     }
 
 
-    private fun defaultSlotStart(schedule: Schedule): java.time.Instant {
-        return LocalDate.parse(schedule.room.tripDate.toString())
-            .atTime(9, 0)
-            .atZone(ZoneId.of("Asia/Seoul"))
+
+    private fun validateConfirmedSchedule(schedule: Schedule) {
+        if (!schedule.isConfirmed) {
+            throw DomainException(HttpStatus.CONFLICT, "SCHEDULE_NOT_CONFIRMED", "확정된 일정만 수정할 수 있습니다.")
+        }
+    }
+
+    private fun redistributeSlotsWithinScheduleWindow(schedule: Schedule, slots: List<ScheduleSlot>) {
+        val activeSlots = slots.sortedBy { it.orderIndex }
+        if (activeSlots.isEmpty()) return
+
+        val window = scheduleTimeWindow(schedule)
+        var cursor = window.first
+
+        activeSlots.forEachIndexed { index, slot ->
+            val remainingSlots = activeSlots.size - index
+            val remainingMinutes = Duration.between(cursor, window.second).toMinutes().coerceAtLeast(remainingSlots.toLong())
+            val duration = if (index == activeSlots.lastIndex) {
+                remainingMinutes
+            } else {
+                (remainingMinutes / remainingSlots).coerceAtLeast(1)
+            }
+            slot.startTime = cursor
+            slot.endTime = if (index == activeSlots.lastIndex) window.second else cursor.plus(Duration.ofMinutes(duration))
+            cursor = slot.endTime
+        }
+    }
+
+    private fun scheduleTimeWindow(schedule: Schedule): Pair<java.time.Instant, java.time.Instant> {
+        val input = schedule.generationInput
+        val startText = input["startTime"]?.toString()?.takeIf { it.isNotBlank() } ?: "09:00"
+        val endText = input["endTime"]?.toString()?.takeIf { it.isNotBlank() } ?: "21:00"
+        val tripDate = LocalDate.parse(schedule.room.tripDate.toString())
+        val zone = ZoneId.of("Asia/Seoul")
+        val startParts = startText.split(":")
+        val endParts = endText.split(":")
+        val start = tripDate
+            .atTime(startParts.getOrNull(0)?.toIntOrNull() ?: 9, startParts.getOrNull(1)?.toIntOrNull() ?: 0)
+            .atZone(zone)
             .toInstant()
+        var end = tripDate
+            .atTime(endParts.getOrNull(0)?.toIntOrNull() ?: 21, endParts.getOrNull(1)?.toIntOrNull() ?: 0)
+            .atZone(zone)
+            .toInstant()
+        if (!end.isAfter(start)) {
+            end = start.plus(Duration.ofHours(12))
+        }
+        return start to end
+    }
+
+    private fun defaultSlotStart(schedule: Schedule): java.time.Instant {
+        return scheduleTimeWindow(schedule).first
     }
 
     private fun isDepopulationArea(metadataTags: Map<String, Any>?): Boolean {

--- a/src/main/kotlin/com/tripsync/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/tripsync/common/exception/GlobalExceptionHandler.kt
@@ -5,6 +5,8 @@ import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.servlet.NoHandlerFoundException
+import org.springframework.web.servlet.resource.NoResourceFoundException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -20,6 +22,14 @@ class GlobalExceptionHandler {
             .body(ApiResponse.error(ex.code, ex.message))
     }
 
+    @ExceptionHandler(NoHandlerFoundException::class, NoResourceFoundException::class)
+    fun handleNotFoundException(ex: Exception): ResponseEntity<ApiResponse<Nothing>> {
+        logger.warn { "[NOT_FOUND] ${ex.message}" }
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.error("NOT_FOUND", "요청한 API를 찾을 수 없습니다."))
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
         val message = ex.bindingResult.fieldErrors.joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
@@ -33,6 +43,6 @@ class GlobalExceptionHandler {
         logger.error(ex) { "Unexpected error occurred" }
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ApiResponse.error("INTERNAL_ERROR", "서버 낶부 오류가 발생했습니다."))
+            .body(ApiResponse.error("INTERNAL_ERROR", "서버 내부 오류가 발생했습니다."))
     }
 }

--- a/src/main/kotlin/com/tripsync/web/dto/AuthDto.kt
+++ b/src/main/kotlin/com/tripsync/web/dto/AuthDto.kt
@@ -6,6 +6,7 @@ import com.tripsync.domain.entity.AxisScores
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import org.springframework.http.HttpStatus
 
@@ -119,4 +120,9 @@ data class RegenerateScheduleDto(
 data class ReorderScheduleSlotsDto(
     @field:NotEmpty
     val slotIds: List<Long>,
+)
+
+data class AddScheduleSlotDto(
+    @field:NotNull
+    val placeId: Long?,
 )

--- a/src/main/kotlin/com/tripsync/web/dto/AuthDto.kt
+++ b/src/main/kotlin/com/tripsync/web/dto/AuthDto.kt
@@ -6,7 +6,6 @@ import com.tripsync.domain.entity.AxisScores
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import org.springframework.http.HttpStatus
 
@@ -123,6 +122,5 @@ data class ReorderScheduleSlotsDto(
 )
 
 data class AddScheduleSlotDto(
-    @field:NotNull
-    val placeId: Long?,
+    val placeId: Long,
 )

--- a/src/main/kotlin/com/tripsync/web/room/RoomController.kt
+++ b/src/main/kotlin/com/tripsync/web/room/RoomController.kt
@@ -25,6 +25,11 @@ class RoomController(
         return roomService.createRoom(currentUser(), dto.destination, LocalDate.parse(dto.tripDate))
     }
 
+    @GetMapping("/my")
+    fun getMyRooms(): ApiResponse<Map<String, Any>> {
+        return roomService.getMyRooms(currentUser())
+    }
+
     @GetMapping("/share/{shareCode}")
     fun getShareRoom(@PathVariable shareCode: String): ApiResponse<Map<String, Any>> {
         return roomService.getShareRoom(shareCode)

--- a/src/main/kotlin/com/tripsync/web/schedule/ScheduleController.kt
+++ b/src/main/kotlin/com/tripsync/web/schedule/ScheduleController.kt
@@ -4,6 +4,7 @@ import com.tripsync.application.auth.CustomUserDetailsService
 import com.tripsync.application.schedule.ScheduleService
 import com.tripsync.common.dto.ApiResponse
 import com.tripsync.common.exception.DomainException
+import com.tripsync.web.dto.AddScheduleSlotDto
 import com.tripsync.web.dto.ConfirmScheduleDto
 import com.tripsync.web.dto.GenerateScheduleDto
 import com.tripsync.web.dto.RegenerateScheduleDto
@@ -47,6 +48,23 @@ class ScheduleController(
     @GetMapping("/schedules/{scheduleId}")
     fun getSchedule(@PathVariable scheduleId: Long): ApiResponse<Map<String, Any?>> {
         return scheduleService.getSchedule(scheduleId, currentUser().id)
+    }
+
+    @GetMapping("/schedules/{scheduleId}/places/search")
+    fun searchSchedulePlaces(
+        @PathVariable scheduleId: Long,
+        @RequestParam(required = false, defaultValue = "") query: String,
+    ): ApiResponse<Map<String, Any?>> {
+        return scheduleService.searchPlacesForSchedule(scheduleId, currentUser().id, query)
+    }
+
+    @PostMapping("/schedules/{scheduleId}/slots")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun addScheduleSlot(
+        @PathVariable scheduleId: Long,
+        @Valid @RequestBody dto: AddScheduleSlotDto,
+    ): ApiResponse<Map<String, Any?>> {
+        return scheduleService.addScheduleSlot(scheduleId, currentUser().id, dto.placeId!!)
     }
 
     @PatchMapping("/schedules/{scheduleId}/slots/order")

--- a/src/main/kotlin/com/tripsync/web/schedule/ScheduleController.kt
+++ b/src/main/kotlin/com/tripsync/web/schedule/ScheduleController.kt
@@ -64,7 +64,7 @@ class ScheduleController(
         @PathVariable scheduleId: Long,
         @Valid @RequestBody dto: AddScheduleSlotDto,
     ): ApiResponse<Map<String, Any?>> {
-        return scheduleService.addScheduleSlot(scheduleId, currentUser().id, dto.placeId!!)
+        return scheduleService.addScheduleSlot(scheduleId, currentUser().id, dto.placeId)
     }
 
     @PatchMapping("/schedules/{scheduleId}/slots/order")

--- a/src/test/kotlin/com/tripsync/AuthContractTests.kt
+++ b/src/test/kotlin/com/tripsync/AuthContractTests.kt
@@ -175,6 +175,22 @@ class AuthContractTests(
     }
 
     @Test
+    fun `host can see created rooms from home entry list`() {
+        val hostSession = registerSession("host-rooms@example.com", "방목록")
+        val firstRoomId = createRoom(hostSession)
+        val secondRoomId = createRoom(hostSession)
+
+        mockMvc.get("/rooms/my") { cookie(hostSession) }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data.rooms[0].roomId") { value(secondRoomId.toInt()) }
+                jsonPath("$.data.rooms[1].roomId") { value(firstRoomId.toInt()) }
+                jsonPath("$.data.rooms[0].destination") { value("충청남도") }
+                jsonPath("$.data.rooms[0].memberCount") { value(1) }
+            }
+    }
+
+    @Test
     fun `oauth start sets state cookie and local callback creates session`() {
         val start = mockMvc.get("/auth/google") {
             param("redirectPath", "/rooms/new")

--- a/src/test/kotlin/com/tripsync/application/schedule/ScheduleServiceTest.kt
+++ b/src/test/kotlin/com/tripsync/application/schedule/ScheduleServiceTest.kt
@@ -1,0 +1,153 @@
+package com.tripsync.application.schedule
+
+import com.tripsync.common.exception.DomainException
+import com.tripsync.domain.entity.Place
+import com.tripsync.domain.entity.RoomMember
+import com.tripsync.domain.entity.Schedule
+import com.tripsync.domain.entity.ScheduleSlot
+import com.tripsync.domain.entity.TripRoom
+import com.tripsync.domain.entity.User
+import com.tripsync.domain.enums.AuthProvider
+import com.tripsync.domain.enums.ReasonAxis
+import com.tripsync.domain.enums.RoomMemberRole
+import com.tripsync.domain.enums.ScheduleOptionType
+import com.tripsync.domain.enums.SlotType
+import com.tripsync.domain.enums.TripRoomStatus
+import com.tripsync.domain.repository.PlaceRepository
+import com.tripsync.domain.repository.RoomMemberRepository
+import com.tripsync.domain.repository.ScheduleRepository
+import com.tripsync.domain.repository.ScheduleSlotRepository
+import com.tripsync.domain.repository.TripRoomRepository
+import com.tripsync.domain.repository.UserRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ScheduleServiceTest(
+    @Autowired private val scheduleService: ScheduleService,
+    @Autowired private val userRepository: UserRepository,
+    @Autowired private val tripRoomRepository: TripRoomRepository,
+    @Autowired private val roomMemberRepository: RoomMemberRepository,
+    @Autowired private val scheduleRepository: ScheduleRepository,
+    @Autowired private val scheduleSlotRepository: ScheduleSlotRepository,
+    @Autowired private val placeRepository: PlaceRepository,
+) {
+    @Test
+    fun `host can search places and append a selected place to confirmed schedule`() {
+        val fixture = createFixture()
+
+        val searchBefore = scheduleService.searchPlacesForSchedule(fixture.schedule.id, fixture.host.id, "꽃지").data!!
+        val placesBefore = searchBefore["places"] as List<*>
+        val candidateBefore = placesBefore
+            .map { it as Map<*, *> }
+            .first { it["id"] == fixture.newPlace.id }
+        assertEquals(false, candidateBefore["alreadyAdded"])
+
+        val added = scheduleService.addScheduleSlot(fixture.schedule.id, fixture.host.id, fixture.newPlace.id).data!!
+        val addedSlots = added["slots"] as List<*>
+        val appended = addedSlots.last() as Map<*, *>
+        assertEquals(2, appended["orderIndex"])
+        assertEquals(fixture.newPlace.name, (appended["place"] as Map<*, *>)["name"])
+        assertEquals("직접 추가한 장소입니다.", appended["reason"])
+        assertNotNull(appended["slotId"])
+
+        val searchAfter = scheduleService.searchPlacesForSchedule(fixture.schedule.id, fixture.host.id, "꽃지").data!!
+        val candidateAfter = (searchAfter["places"] as List<*>)
+            .map { it as Map<*, *> }
+            .first { it["id"] == fixture.newPlace.id }
+        assertEquals(true, candidateAfter["alreadyAdded"])
+    }
+
+    @Test
+    fun `adding the same place twice is rejected`() {
+        val fixture = createFixture()
+
+        scheduleService.addScheduleSlot(fixture.schedule.id, fixture.host.id, fixture.newPlace.id)
+
+        val error = assertThrows(DomainException::class.java) {
+            scheduleService.addScheduleSlot(fixture.schedule.id, fixture.host.id, fixture.newPlace.id)
+        }
+        assertEquals("INVALID_REQUEST", error.code)
+    }
+
+    private fun createFixture(): Fixture {
+        val suffix = System.nanoTime()
+        val host = userRepository.save(
+            User(
+                nickname = "host-$suffix",
+                email = "host-$suffix@example.com",
+                authProvider = AuthProvider.LOCAL,
+                passwordHash = "password",
+            )
+        )
+        val room = tripRoomRepository.save(
+            TripRoom(
+                hostUser = host,
+                shareCode = "S${suffix.toString().takeLast(10)}",
+                destination = "충남",
+                tripDate = LocalDate.now().plusDays(7),
+                status = TripRoomStatus.COMPLETED,
+            )
+        )
+        roomMemberRepository.save(RoomMember(room = room, user = host, role = RoomMemberRole.HOST))
+
+        val firstPlace = placeRepository.save(place("existing-$suffix", "고향굴수산", "충청남도 보령시 전북면 홍보로 1061-103"))
+        val newPlace = placeRepository.save(place("new-$suffix", "태안 안면도 꽃지해수욕장", "충청남도 태안군 안면읍 승언리"))
+        val schedule = scheduleRepository.save(
+            Schedule(
+                room = room,
+                version = 1,
+                optionType = ScheduleOptionType.BALANCED,
+                isConfirmed = true,
+                generationInput = mapOf("destination" to "충남"),
+                summary = "확정 일정",
+                groupSatisfaction = 80,
+            )
+        )
+        scheduleSlotRepository.save(
+            ScheduleSlot(
+                schedule = schedule,
+                startTime = Instant.parse("2026-06-01T00:00:00Z"),
+                endTime = Instant.parse("2026-06-01T02:00:00Z"),
+                place = firstPlace,
+                slotType = SlotType.COMMON,
+                reasonAxis = ReasonAxis.COMMON,
+                reasonText = "기존 장소",
+                orderIndex = 1,
+            )
+        )
+
+        return Fixture(host, schedule, newPlace)
+    }
+
+    private fun place(tourApiId: String, name: String, address: String): Place {
+        return Place(
+            tourApiId = tourApiId,
+            name = name,
+            address = address,
+            latitude = BigDecimal("36.5000000"),
+            longitude = BigDecimal("126.5000000"),
+            category = "관광지",
+            mobilityScore = 50,
+            photoScore = 80,
+            budgetScore = 60,
+            themeScore = 40,
+            metadataTags = mapOf("populationDeclineArea" to true),
+        )
+    }
+
+    private data class Fixture(
+        val host: User,
+        val schedule: Schedule,
+        val newPlace: Place,
+    )
+}

--- a/src/test/kotlin/com/tripsync/application/schedule/ScheduleServiceTest.kt
+++ b/src/test/kotlin/com/tripsync/application/schedule/ScheduleServiceTest.kt
@@ -21,6 +21,7 @@ import com.tripsync.domain.repository.TripRoomRepository
 import com.tripsync.domain.repository.UserRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -29,6 +30,7 @@ import org.springframework.test.context.ActiveProfiles
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -59,12 +61,32 @@ class ScheduleServiceTest(
         assertEquals(fixture.newPlace.name, (appended["place"] as Map<*, *>)["name"])
         assertEquals("직접 추가한 장소입니다.", appended["reason"])
         assertNotNull(appended["slotId"])
+        val first = addedSlots.first() as Map<*, *>
+        assertEquals(first["endTime"], appended["startTime"])
+        assertTrue(Instant.parse(first["startTime"].toString()) >= fixture.windowStart)
+        assertTrue(Instant.parse(appended["endTime"].toString()) <= fixture.windowEnd)
 
         val searchAfter = scheduleService.searchPlacesForSchedule(fixture.schedule.id, fixture.host.id, "꽃지").data!!
         val candidateAfter = (searchAfter["places"] as List<*>)
             .map { it as Map<*, *> }
             .first { it["id"] == fixture.newPlace.id }
         assertEquals(true, candidateAfter["alreadyAdded"])
+    }
+
+
+    @Test
+    fun `unconfirmed schedule cannot be searched or edited`() {
+        val fixture = createFixture(isConfirmed = false)
+
+        val searchError = assertThrows(DomainException::class.java) {
+            scheduleService.searchPlacesForSchedule(fixture.schedule.id, fixture.host.id, "꽃지")
+        }
+        assertEquals("SCHEDULE_NOT_CONFIRMED", searchError.code)
+
+        val addError = assertThrows(DomainException::class.java) {
+            scheduleService.addScheduleSlot(fixture.schedule.id, fixture.host.id, fixture.newPlace.id)
+        }
+        assertEquals("SCHEDULE_NOT_CONFIRMED", addError.code)
     }
 
     @Test
@@ -79,7 +101,7 @@ class ScheduleServiceTest(
         assertEquals("INVALID_REQUEST", error.code)
     }
 
-    private fun createFixture(): Fixture {
+    private fun createFixture(isConfirmed: Boolean = true): Fixture {
         val suffix = System.nanoTime()
         val host = userRepository.save(
             User(
@@ -107,8 +129,8 @@ class ScheduleServiceTest(
                 room = room,
                 version = 1,
                 optionType = ScheduleOptionType.BALANCED,
-                isConfirmed = true,
-                generationInput = mapOf("destination" to "충남"),
+                isConfirmed = isConfirmed,
+                generationInput = mapOf("destination" to "충남", "startTime" to "09:00", "endTime" to "21:00"),
                 summary = "확정 일정",
                 groupSatisfaction = 80,
             )
@@ -126,7 +148,17 @@ class ScheduleServiceTest(
             )
         )
 
-        return Fixture(host, schedule, newPlace)
+        val zone = ZoneId.of("Asia/Seoul")
+        val windowStart = room.tripDate
+            .atTime(9, 0)
+            .atZone(zone)
+            .toInstant()
+        val windowEnd = room.tripDate
+            .atTime(21, 0)
+            .atZone(zone)
+            .toInstant()
+
+        return Fixture(host, schedule, newPlace, windowStart, windowEnd)
     }
 
     private fun place(tourApiId: String, name: String, address: String): Place {
@@ -149,5 +181,7 @@ class ScheduleServiceTest(
         val host: User,
         val schedule: Schedule,
         val newPlace: Place,
+        val windowStart: Instant,
+        val windowEnd: Instant,
     )
 }


### PR DESCRIPTION
## Summary

- 내 여행방 목록 조회 API 추가

## Changes

- 로그인 사용자 참여 방 목록 조회 엔드포인트 추가
- 홈 재진입용 방 요약 응답 구성
- 생성 방 목록 정렬 및 멤버 수 포함
- 방 목록 조회 계약 테스트 추가

## Verification

- [x] Build: `./gradlew -q compileKotlin`
- [x] Test: `./gradlew test --no-daemon --no-build-cache`
- [x] Manual: 회원가입 → 방 생성 → `/api/rooms/my` 조회

## Notes

- 웹 `push-main` 별도 푸시 완료
