### PR TITLE
Refactor: 일정 생성 트랜잭션 경계 분리

### DIFF
--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleGenerationPersistenceService.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleGenerationPersistenceService.kt
@@ -1,0 +1,186 @@
+package com.tripsync.application.schedule
+
+import com.tripsync.domain.entity.AxisScores
+import com.tripsync.application.consensus.MemberSnapshot
+import com.tripsync.application.consensus.PlaceCandidate
+import com.tripsync.application.consensus.ScheduleOptionDraft
+import com.tripsync.common.exception.DomainException
+import com.tripsync.domain.entity.Place
+import com.tripsync.domain.entity.SatisfactionScore
+import com.tripsync.domain.entity.Schedule
+import com.tripsync.domain.entity.ScheduleSlot
+import com.tripsync.domain.enums.ScheduleOptionType
+import com.tripsync.domain.enums.TripRoomStatus
+import com.tripsync.domain.enums.YnFlag
+import com.tripsync.domain.repository.PlaceRepository
+import com.tripsync.domain.repository.RoomMemberProfileRepository
+import com.tripsync.domain.repository.SatisfactionScoreRepository
+import com.tripsync.domain.repository.ScheduleRepository
+import com.tripsync.domain.repository.ScheduleSlotRepository
+import com.tripsync.domain.repository.UserRepository
+import com.tripsync.web.dto.GenerateScheduleDto
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ScheduleGenerationPersistenceService(
+    private val scheduleRepository: ScheduleRepository,
+    private val scheduleSlotRepository: ScheduleSlotRepository,
+    private val satisfactionScoreRepository: SatisfactionScoreRepository,
+    private val roomMemberProfileRepository: RoomMemberProfileRepository,
+    private val placeRepository: PlaceRepository,
+    private val userRepository: UserRepository,
+    private val accessPolicy: ScheduleAccessPolicy,
+) {
+    @Transactional(readOnly = true)
+    fun loadGenerationContext(roomId: Long, hostId: Long): ScheduleGenerationContext {
+        accessPolicy.validateHost(roomId, hostId)
+        accessPolicy.getActiveRoom(roomId)
+        val profiles = roomMemberProfileRepository.findAllByRoomIdAndDelYn(roomId, YnFlag.N)
+            .sortedBy { it.createdAt }
+        if (profiles.size < 2) {
+            throw DomainException(HttpStatus.UNPROCESSABLE_ENTITY, "ROOM_NOT_READY", "일정 생성 가능한 상태가 아닙니다.")
+        }
+
+        val members = profiles.mapIndexed { index, profile ->
+            MemberSnapshot(
+                userId = profile.user.id,
+                nickname = profile.user.nickname,
+                scores = AxisScores(
+                    mobility = profile.mobilityScore,
+                    photo = profile.photoScore,
+                    budget = profile.budgetScore,
+                    theme = profile.themeScore,
+                ),
+                joinedOrder = index,
+            )
+        }
+
+        val places = placeRepository.findByDelYn(YnFlag.N)
+        val placeCandidates = places.map {
+            PlaceCandidate(
+                id = it.id,
+                name = it.name,
+                address = it.address,
+                category = it.category,
+                mobilityScore = it.mobilityScore,
+                photoScore = it.photoScore,
+                budgetScore = it.budgetScore,
+                themeScore = it.themeScore,
+                metadataTags = it.metadataTags,
+                operatingHours = it.operatingHours,
+            )
+        }
+
+        return ScheduleGenerationContext(
+            roomId = roomId,
+            members = members,
+            places = placeCandidates,
+            placesById = places.associateBy { it.id },
+        )
+    }
+
+    @Transactional
+    fun saveGeneratedOptions(
+        roomId: Long,
+        dto: GenerateScheduleDto,
+        options: List<ScheduleOptionDraft>,
+        personaValidationByType: Map<ScheduleOptionType, Map<String, Any>>,
+    ): SavedScheduleGeneration {
+        val room = accessPolicy.getActiveRoom(roomId)
+        val version = (scheduleRepository.findTopByRoomIdAndDelYnOrderByVersionDesc(room.id, YnFlag.N)?.version ?: 0) + 1
+        val saved = options.map { option ->
+            val personaValidation = personaValidationByType[option.optionType]
+            val schedule = scheduleRepository.save(
+                Schedule(
+                    room = room,
+                    version = version,
+                    optionType = option.optionType,
+                    generationInput = mapOf(
+                        "destination" to dto.destination,
+                        "tripDate" to dto.tripDate,
+                        "startTime" to dto.startTime,
+                        "endTime" to dto.endTime,
+                    ),
+                    summary = option.summary,
+                    groupSatisfaction = option.groupSatisfaction,
+                    personaValidation = personaValidation,
+                    llmProvider = option.llmProvider,
+                )
+            )
+
+            option.slots.forEach { slot ->
+                val place = placeRepository.findById(slot.placeId)
+                    .orElseThrow { DomainException(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소를 찾을 수 없습니다.") }
+                if (place.delYn != YnFlag.N) {
+                    throw DomainException(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소를 찾을 수 없습니다.")
+                }
+                val targetUser = slot.targetUserId?.let { userRepository.findById(it).orElse(null) }
+                scheduleSlotRepository.save(
+                    ScheduleSlot(
+                        schedule = schedule,
+                        startTime = slot.startTime,
+                        endTime = slot.endTime,
+                        place = place,
+                        slotType = slot.slotType,
+                        targetUser = targetUser,
+                        reasonAxis = slot.reasonAxis,
+                        reasonText = slot.reasonText,
+                        orderIndex = slot.orderIndex,
+                    )
+                )
+            }
+
+            option.satisfactionByUser.forEach { sat ->
+                val user = userRepository.findById(sat.userId)
+                    .orElseThrow { DomainException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다: ${sat.userId}") }
+                satisfactionScoreRepository.save(
+                    SatisfactionScore(
+                        schedule = schedule,
+                        user = user,
+                        score = sat.score,
+                        breakdown = mapOf(
+                            "overall" to sat.score,
+                            "byAxis" to sat.breakdown.byAxis.mapKeys { it.key.name.lowercase() },
+                        ),
+                    )
+                )
+            }
+
+            SavedScheduleOption(
+                scheduleId = schedule.id,
+                option = option,
+                personaValidation = personaValidation,
+            )
+        }
+        room.status = TripRoomStatus.COMPLETED
+        return SavedScheduleGeneration(version = version, options = saved)
+    }
+
+    @Transactional(readOnly = true)
+    fun getRoomIdForRegeneration(scheduleId: Long, userId: Long): Long {
+        val existing = accessPolicy.getActiveSchedule(scheduleId)
+        val roomId = existing.room.id
+        accessPolicy.validateHost(roomId, userId)
+        return roomId
+    }
+}
+
+data class ScheduleGenerationContext(
+    val roomId: Long,
+    val members: List<MemberSnapshot>,
+    val places: List<PlaceCandidate>,
+    val placesById: Map<Long, Place>,
+)
+
+data class SavedScheduleGeneration(
+    val version: Int,
+    val options: List<SavedScheduleOption>,
+)
+
+data class SavedScheduleOption(
+    val scheduleId: Long,
+    val option: ScheduleOptionDraft,
+    val personaValidation: Map<String, Any>?,
+)

--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
@@ -6,7 +6,6 @@ import com.tripsync.common.dto.ApiResponse
 import com.tripsync.common.exception.DomainException
 import com.tripsync.domain.entity.*
 import com.tripsync.domain.enums.ScheduleOptionType
-import com.tripsync.domain.enums.TripRoomStatus
 import com.tripsync.domain.enums.YnFlag
 import com.tripsync.domain.repository.*
 import com.tripsync.web.dto.GenerateScheduleDto
@@ -24,56 +23,19 @@ import java.time.ZoneId
 class ScheduleService(
     private val scheduleRepository: ScheduleRepository,
     private val scheduleSlotRepository: ScheduleSlotRepository,
-    private val satisfactionScoreRepository: SatisfactionScoreRepository,
-    private val roomMemberProfileRepository: RoomMemberProfileRepository,
     private val placeRepository: PlaceRepository,
-    private val userRepository: UserRepository,
     private val consensusService: ConsensusService,
+    private val generationPersistenceService: ScheduleGenerationPersistenceService,
     private val personaValidationService: PersonaValidationService,
     private val accessPolicy: ScheduleAccessPolicy,
     private val responseMapper: ScheduleResponseMapper,
 ) {
     private val logger = KotlinLogging.logger {}
 
-    @Transactional
     fun generateSchedule(roomId: Long, hostId: Long, dto: GenerateScheduleDto): ApiResponse<Map<String, Any?>> {
-        accessPolicy.validateHost(roomId, hostId)
-        val room = accessPolicy.getActiveRoom(roomId)
-        val profiles = roomMemberProfileRepository.findAllByRoomIdAndDelYn(roomId, YnFlag.N)
-            .sortedBy { it.createdAt }
-        if (profiles.size < 2) {
-            throw DomainException(HttpStatus.UNPROCESSABLE_ENTITY, "ROOM_NOT_READY", "일정 생성 가능한 상태가 아닙니다.")
-        }
-
-        val members = profiles.mapIndexed { index, profile ->
-            MemberSnapshot(
-                userId = profile.user.id,
-                nickname = profile.user.nickname,
-                scores = AxisScores(
-                    mobility = profile.mobilityScore,
-                    photo = profile.photoScore,
-                    budget = profile.budgetScore,
-                    theme = profile.themeScore,
-                ),
-                joinedOrder = index,
-            )
-        }
-
-        val places = placeRepository.findByDelYn(YnFlag.N)
-        val placeCandidates = places.map {
-            PlaceCandidate(
-                id = it.id,
-                name = it.name,
-                address = it.address,
-                category = it.category,
-                mobilityScore = it.mobilityScore,
-                photoScore = it.photoScore,
-                budgetScore = it.budgetScore,
-                themeScore = it.themeScore,
-                metadataTags = it.metadataTags,
-                operatingHours = it.operatingHours,
-            )
-        }
+        val generationContext = generationPersistenceService.loadGenerationContext(roomId, hostId)
+        val members = generationContext.members
+        val placesById = generationContext.placesById
 
         val context = OptionContext(
             roomId = roomId,
@@ -82,28 +44,28 @@ class ScheduleService(
             startTime = dto.startTime,
             endTime = dto.endTime,
             members = members,
-            places = placeCandidates,
+            places = generationContext.places,
         )
 
         val options = runBlocking { consensusService.buildScheduleOptions(context) }
-        val placesById = places.associateBy { it.id }
         val personaValidationByType = safePersonaValidationByType(options, members, placesById)
-        val version = (scheduleRepository.findTopByRoomIdAndDelYnOrderByVersionDesc(room.id, YnFlag.N)?.version ?: 0) + 1
-        val saved = options.map { option ->
-            saveScheduleOption(room, version, dto, option, personaValidationByType[option.optionType])
-        }
-        room.status = TripRoomStatus.COMPLETED
+        val savedGeneration = generationPersistenceService.saveGeneratedOptions(
+            roomId = roomId,
+            dto = dto,
+            options = options,
+            personaValidationByType = personaValidationByType,
+        )
 
         val memberNicknames = members.associate { it.userId to it.nickname }
         return ApiResponse.ok(
             mapOf(
                 "roomId" to roomId,
-                "version" to version,
-                "options" to saved.map { (schedule, option) ->
+                "version" to savedGeneration.version,
+                "options" to savedGeneration.options.map { saved ->
                     responseMapper.formatGeneratedOption(
-                        scheduleId = schedule.id,
-                        option = option,
-                        personaValidation = schedule.personaValidation,
+                        scheduleId = saved.scheduleId,
+                        option = saved.option,
+                        personaValidation = saved.personaValidation,
                         memberNicknames = memberNicknames,
                         placesById = placesById,
                     )
@@ -240,12 +202,10 @@ class ScheduleService(
         )
     }
 
-    @Transactional
     fun regenerateSchedule(scheduleId: Long, userId: Long, dto: RegenerateScheduleDto): ApiResponse<Map<String, Any?>> {
-        val existing = accessPolicy.getActiveSchedule(scheduleId)
-        accessPolicy.validateHost(existing.room.id, userId)
+        val roomId = generationPersistenceService.getRoomIdForRegeneration(scheduleId, userId)
         val generated = generateSchedule(
-            existing.room.id,
+            roomId,
             userId,
             GenerateScheduleDto(
                 destination = dto.destination,
@@ -273,69 +233,6 @@ class ScheduleService(
     fun getPublicShareSchedule(scheduleId: Long): ApiResponse<Map<String, Any?>> {
         val schedule = accessPolicy.getActiveSchedule(scheduleId)
         return ApiResponse.ok(responseMapper.formatStoredSchedule(schedule))
-    }
-
-    private fun saveScheduleOption(
-        room: TripRoom,
-        version: Int,
-        dto: GenerateScheduleDto,
-        option: ScheduleOptionDraft,
-        personaValidation: Map<String, Any>?,
-    ): Pair<Schedule, ScheduleOptionDraft> {
-        val schedule = scheduleRepository.save(
-            Schedule(
-                room = room,
-                version = version,
-                optionType = option.optionType,
-                generationInput = mapOf(
-                    "destination" to dto.destination,
-                    "tripDate" to dto.tripDate,
-                    "startTime" to dto.startTime,
-                    "endTime" to dto.endTime,
-                ),
-                summary = option.summary,
-                groupSatisfaction = option.groupSatisfaction,
-                personaValidation = personaValidation,
-                llmProvider = option.llmProvider,
-            )
-        )
-
-        option.slots.forEach { slot ->
-            val place = placeRepository.findById(slot.placeId)
-                .orElseThrow { DomainException(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소를 찾을 수 없습니다.") }
-            val targetUser = slot.targetUserId?.let { userRepository.findById(it).orElse(null) }
-            scheduleSlotRepository.save(
-                ScheduleSlot(
-                    schedule = schedule,
-                    startTime = slot.startTime,
-                    endTime = slot.endTime,
-                    place = place,
-                    slotType = slot.slotType,
-                    targetUser = targetUser,
-                    reasonAxis = slot.reasonAxis,
-                    reasonText = slot.reasonText,
-                    orderIndex = slot.orderIndex,
-                )
-            )
-        }
-
-        option.satisfactionByUser.forEach { sat ->
-            val user = userRepository.findById(sat.userId)
-                .orElseThrow { DomainException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다: ${sat.userId}") }
-            satisfactionScoreRepository.save(
-                SatisfactionScore(
-                    schedule = schedule,
-                    user = user,
-                    score = sat.score,
-                    breakdown = mapOf(
-                        "overall" to sat.score,
-                        "byAxis" to sat.breakdown.byAxis.mapKeys { it.key.name.lowercase() },
-                    ),
-                )
-            )
-        }
-
-        return schedule to option
     }
 
     private fun safePersonaValidationByType(


### PR DESCRIPTION
## Summary

- 일정 생성 트랜잭션 경계 분리

## Changes

- `ScheduleGenerationPersistenceService` 추가
- 일정 생성 데이터 조회/read-only 트랜잭션 분리
- consensus·LLM refinement 가능 구간 트랜잭션 밖 실행
- 일정/슬롯/만족도 저장 쓰기 트랜잭션 축소
- 저장 직전 장소 soft-delete 재검증 추가
- 재생성 권한 확인 후 동일 생성 경로 재사용

## Verification

- [ ] Not run
- [ ] Build
- [x] Test: `./gradlew test --rerun-tasks --no-daemon`
- [ ] Manual

## Notes

-
