### PR TITLE
Perf: 장소 후보 검색 쿼리 최적화

### DIFF
--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleGenerationPersistenceService.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleGenerationPersistenceService.kt
@@ -12,6 +12,7 @@ import com.tripsync.domain.entity.ScheduleSlot
 import com.tripsync.domain.enums.ScheduleOptionType
 import com.tripsync.domain.enums.TripRoomStatus
 import com.tripsync.domain.enums.YnFlag
+import com.tripsync.domain.repository.PlaceQueryRepository
 import com.tripsync.domain.repository.PlaceRepository
 import com.tripsync.domain.repository.RoomMemberProfileRepository
 import com.tripsync.domain.repository.SatisfactionScoreRepository
@@ -30,11 +31,12 @@ class ScheduleGenerationPersistenceService(
     private val satisfactionScoreRepository: SatisfactionScoreRepository,
     private val roomMemberProfileRepository: RoomMemberProfileRepository,
     private val placeRepository: PlaceRepository,
+    private val placeQueryRepository: PlaceQueryRepository,
     private val userRepository: UserRepository,
     private val accessPolicy: ScheduleAccessPolicy,
 ) {
     @Transactional(readOnly = true)
-    fun loadGenerationContext(roomId: Long, hostId: Long): ScheduleGenerationContext {
+    fun loadGenerationContext(roomId: Long, hostId: Long, destination: String): ScheduleGenerationContext {
         accessPolicy.validateHost(roomId, hostId)
         accessPolicy.getActiveRoom(roomId)
         val profiles = roomMemberProfileRepository.findAllByRoomIdAndDelYn(roomId, YnFlag.N)
@@ -57,7 +59,7 @@ class ScheduleGenerationPersistenceService(
             )
         }
 
-        val places = placeRepository.findByDelYn(YnFlag.N)
+        val places = placeQueryRepository.findScheduleCandidates(destination)
         val placeCandidates = places.map {
             PlaceCandidate(
                 id = it.id,

--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
@@ -23,6 +23,7 @@ import java.time.ZoneId
 class ScheduleService(
     private val scheduleRepository: ScheduleRepository,
     private val scheduleSlotRepository: ScheduleSlotRepository,
+    private val placeQueryRepository: PlaceQueryRepository,
     private val placeRepository: PlaceRepository,
     private val consensusService: ConsensusService,
     private val generationPersistenceService: ScheduleGenerationPersistenceService,
@@ -33,7 +34,7 @@ class ScheduleService(
     private val logger = KotlinLogging.logger {}
 
     fun generateSchedule(roomId: Long, hostId: Long, dto: GenerateScheduleDto): ApiResponse<Map<String, Any?>> {
-        val generationContext = generationPersistenceService.loadGenerationContext(roomId, hostId)
+        val generationContext = generationPersistenceService.loadGenerationContext(roomId, hostId, dto.destination)
         val members = generationContext.members
         val placesById = generationContext.placesById
 
@@ -88,18 +89,9 @@ class ScheduleService(
         accessPolicy.validateHost(schedule.room.id, userId)
         accessPolicy.validateConfirmedSchedule(schedule)
 
-        val normalizedQuery = query.trim().lowercase()
-        val usedPlaceIds = scheduleSlotRepository.findAllByScheduleIdAndDelYn(schedule.id, YnFlag.N)
-            .map { it.place.id }
-            .toSet()
-        val places = placeRepository.findByDelYn(YnFlag.N)
+        val usedPlaceIds = scheduleSlotRepository.findActivePlaceIdsByScheduleId(schedule.id).toSet()
+        val places = placeQueryRepository.searchActivePlaces(query.trim())
             .asSequence()
-            .filter { place ->
-                normalizedQuery.isBlank() ||
-                    place.name.lowercase().contains(normalizedQuery) ||
-                    place.address.lowercase().contains(normalizedQuery) ||
-                    place.category.lowercase().contains(normalizedQuery)
-            }
             .sortedWith(
                 compareByDescending<Place> { responseMapper.isDepopulationArea(it.metadataTags) }
                     .thenBy { it.name }

--- a/src/main/kotlin/com/tripsync/domain/repository/PlaceQueryRepository.kt
+++ b/src/main/kotlin/com/tripsync/domain/repository/PlaceQueryRepository.kt
@@ -1,0 +1,107 @@
+package com.tripsync.domain.repository
+
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.tripsync.domain.entity.Place
+import com.tripsync.domain.entity.QPlace
+import com.tripsync.domain.enums.YnFlag
+import org.springframework.stereotype.Repository
+
+@Repository
+class PlaceQueryRepository(
+    private val jpaQueryFactory: JPAQueryFactory,
+) {
+    private val qPlace = QPlace.place
+
+    fun findScheduleCandidates(destination: String, limit: Long = SCHEDULE_CANDIDATE_LIMIT): List<Place> {
+        val predicate = BooleanBuilder(qPlace.delYn.eq(YnFlag.N))
+        destinationPredicate(destination)?.let { predicate.and(it) }
+
+        return jpaQueryFactory
+            .selectFrom(qPlace)
+            .where(predicate)
+            .orderBy(qPlace.name.asc(), qPlace.id.asc())
+            .limit(limit)
+            .fetch()
+    }
+
+    fun searchActivePlaces(query: String, limit: Long = SEARCH_LIMIT): List<Place> {
+        val normalizedQuery = normalizeSearchQuery(query)
+        val predicate = BooleanBuilder(qPlace.delYn.eq(YnFlag.N))
+        if (normalizedQuery.isNotBlank()) {
+            predicate.and(textSearchPredicate(normalizedQuery))
+        }
+
+        return jpaQueryFactory
+            .selectFrom(qPlace)
+            .where(predicate)
+            .orderBy(populationDeclineRank().desc(), qPlace.name.asc(), qPlace.id.asc())
+            .limit(limit)
+            .fetch()
+    }
+
+    private fun populationDeclineRank() = Expressions.numberTemplate(
+        Int::class.java,
+        "case when function('jsonb_extract_path_text', {0}, 'populationDeclineArea') = 'true' " +
+            "or function('jsonb_extract_path_text', {0}, 'regionType') = 'population_decline' then 1 else 0 end",
+        qPlace.metadataTags,
+    )
+
+    private fun destinationPredicate(destination: String): BooleanBuilder? {
+        val terms = destinationTerms(destination)
+        if (terms.isEmpty()) return null
+
+        return terms.fold(BooleanBuilder()) { builder, term ->
+            builder.or(textSearchPredicate(term))
+        }
+    }
+
+    private fun textSearchPredicate(term: String): BooleanBuilder {
+        val like = "%${term}%"
+        return BooleanBuilder()
+            .or(qPlace.name.lower().like(like))
+            .or(qPlace.address.lower().like(like))
+            .or(qPlace.category.lower().like(like))
+            .or(jsonText("region").lower().like(like))
+            .or(jsonText("area").lower().like(like))
+    }
+
+    private fun jsonText(key: String) = Expressions.stringTemplate(
+        "function('jsonb_extract_path_text', {0}, {1})",
+        qPlace.metadataTags,
+        Expressions.constant(key),
+    )
+
+    private fun destinationTerms(destination: String): Set<String> {
+        val normalized = normalize(destination)
+        if (normalized.isBlank() || normalized in UNBOUNDED_DESTINATIONS) return emptySet()
+
+        return REGION_ALIASES[normalized] ?: setOf(normalized)
+    }
+
+    private fun normalize(value: String): String = value.trim().lowercase().replace(Regex("\\s+"), "")
+
+    private fun normalizeSearchQuery(value: String): String = value.trim().lowercase()
+
+    companion object {
+        const val SEARCH_LIMIT = 120L
+        const val SCHEDULE_CANDIDATE_LIMIT = 500L
+
+        private val UNBOUNDED_DESTINATIONS = setOf("전국", "전체", "all")
+        private val REGION_ALIASES = mapOf(
+            "충남" to setOf("충남", "충청남도"),
+            "충청남도" to setOf("충남", "충청남도"),
+            "충북" to setOf("충북", "충청북도"),
+            "충청북도" to setOf("충북", "충청북도"),
+            "전북" to setOf("전북", "전라북도"),
+            "전라북도" to setOf("전북", "전라북도"),
+            "전남" to setOf("전남", "전라남도"),
+            "전라남도" to setOf("전남", "전라남도"),
+            "경북" to setOf("경북", "경상북도"),
+            "경상북도" to setOf("경북", "경상북도"),
+            "경남" to setOf("경남", "경상남도"),
+            "경상남도" to setOf("경남", "경상남도"),
+        )
+    }
+}

--- a/src/main/kotlin/com/tripsync/domain/repository/ScheduleSlotRepository.kt
+++ b/src/main/kotlin/com/tripsync/domain/repository/ScheduleSlotRepository.kt
@@ -3,9 +3,13 @@ package com.tripsync.domain.repository
 import com.tripsync.domain.entity.ScheduleSlot
 import com.tripsync.domain.enums.YnFlag
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface ScheduleSlotRepository : JpaRepository<ScheduleSlot, Long> {
     fun findAllByScheduleIdAndDelYn(scheduleId: Long, delYn: YnFlag): List<ScheduleSlot>
+
+    @Query("select slot.place.id from ScheduleSlot slot where slot.schedule.id = :scheduleId and slot.delYn = :delYn")
+    fun findActivePlaceIdsByScheduleId(scheduleId: Long, delYn: YnFlag = YnFlag.N): List<Long>
 }

--- a/src/main/resources/db/migration/V4__optimize_place_search_indexes.sql
+++ b/src/main/resources/db/migration/V4__optimize_place_search_indexes.sql
@@ -1,0 +1,10 @@
+-- Optimize active place filtering and keyword/destination lookup paths.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_places_del_yn_id ON places(del_yn, id);
+CREATE INDEX IF NOT EXISTS idx_places_del_yn_category ON places(del_yn, category);
+CREATE INDEX IF NOT EXISTS idx_places_name_trgm ON places USING GIN (lower(name) gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_places_address_trgm ON places USING GIN (lower(address) gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_places_category_trgm ON places USING GIN (lower(category) gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_places_metadata_region_trgm ON places USING GIN (lower(jsonb_extract_path_text(metadata_tags, 'region')) gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_places_metadata_area_trgm ON places USING GIN (lower(jsonb_extract_path_text(metadata_tags, 'area')) gin_trgm_ops);

--- a/src/test/kotlin/com/tripsync/domain/repository/PlaceQueryRepositoryTest.kt
+++ b/src/test/kotlin/com/tripsync/domain/repository/PlaceQueryRepositoryTest.kt
@@ -1,0 +1,77 @@
+package com.tripsync.domain.repository
+
+import com.tripsync.domain.entity.Place
+import com.tripsync.domain.enums.YnFlag
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.math.BigDecimal
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PlaceQueryRepositoryTest(
+    @Autowired private val placeRepository: PlaceRepository,
+    @Autowired private val placeQueryRepository: PlaceQueryRepository,
+) {
+    @Test
+    fun `schedule candidates are filtered by destination alias in database query`() {
+        val suffix = System.nanoTime().toString()
+        val jeonbuk = placeRepository.save(place("jeonbuk-$suffix", "전주 한옥마을 $suffix", "전라북도 전주시 완산구"))
+        val chungnam = placeRepository.save(place("chungnam-$suffix", "태안 꽃지 $suffix", "충청남도 태안군"))
+        val metadataRegion = placeRepository.save(
+            place(
+                tourApiId = "gyeongbuk-$suffix",
+                name = "청도 와인터널 $suffix",
+                address = "상세 주소 미분류 $suffix",
+                metadataTags = mapOf("region" to "경상북도", "area" to "청도군"),
+            )
+        )
+
+        val jeonbukResults = placeQueryRepository.findScheduleCandidates("전북")
+        val gyeongbukResults = placeQueryRepository.findScheduleCandidates("경북")
+
+        assertTrue(jeonbukResults.any { it.id == jeonbuk.id })
+        assertFalse(jeonbukResults.any { it.id == chungnam.id })
+        assertTrue(gyeongbukResults.any { it.id == metadataRegion.id })
+    }
+
+    @Test
+    fun `active place search pushes keyword and deletion filters to database query`() {
+        val suffix = System.nanoTime().toString()
+        val active = placeRepository.save(place("active-$suffix", "꽃지 해수욕장 $suffix", "충청남도 태안군"))
+        val deleted = placeRepository.save(place("deleted-$suffix", "꽃지 삭제장소 $suffix", "충청남도 태안군").also { it.delYn = YnFlag.Y })
+        val unrelated = placeRepository.save(place("unrelated-$suffix", "궁남지 $suffix", "충청남도 부여군"))
+
+        val results = placeQueryRepository.searchActivePlaces("꽃지")
+        val spacedQueryResults = placeQueryRepository.searchActivePlaces("꽃지 해수욕장")
+
+        assertTrue(results.any { it.id == active.id })
+        assertTrue(spacedQueryResults.any { it.id == active.id })
+        assertFalse(results.any { it.id == deleted.id })
+        assertFalse(results.any { it.id == unrelated.id })
+    }
+
+    private fun place(
+        tourApiId: String,
+        name: String,
+        address: String,
+        metadataTags: Map<String, Any>? = null,
+    ): Place {
+        return Place(
+            tourApiId = tourApiId,
+            name = name,
+            address = address,
+            latitude = BigDecimal("36.5000000"),
+            longitude = BigDecimal("126.5000000"),
+            category = "tourist_attraction",
+            mobilityScore = 50,
+            photoScore = 80,
+            budgetScore = 60,
+            themeScore = 40,
+            metadataTags = metadataTags,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- 장소 후보 검색 쿼리 최적화

## Changes

- 일정 생성 후보 장소 조회 QueryDSL repository 추가
- 목적지/지역 별칭 기반 DB 필터링 적용
- 확정 일정 장소 검색 DB 키워드 필터링 적용
- 사용 중인 장소 id 전용 조회 추가
- places 검색용 trigram/활성 상태 인덱스 migration 추가
- 장소 후보 쿼리 회귀 테스트 추가

## Verification

- [ ] Not run
- [ ] Build
- [x] Test: `./gradlew test --rerun-tasks --no-daemon`
- [x] Manual: Docker Postgres `V4__optimize_place_search_indexes.sql` 적용 및 인덱스 생성 확인

## Notes

- 운영 DB `pg_trgm` extension 생성 권한 확인 필요
