### PR TITLE
Feat: TourAPI 동기화 운영화

### DIFF
--- a/src/main/kotlin/com/tripsync/TripSyncApplication.kt
+++ b/src/main/kotlin/com/tripsync/TripSyncApplication.kt
@@ -1,11 +1,13 @@
 package com.tripsync
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
 @EnableJpaAuditing
+@ConfigurationPropertiesScan
 class TripSyncApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/tripsync/application/tourapi/TourApiBatchService.kt
+++ b/src/main/kotlin/com/tripsync/application/tourapi/TourApiBatchService.kt
@@ -9,65 +9,106 @@ import com.tripsync.domain.repository.PlaceRepository
 import com.tripsync.infrastructure.tourapi.TourApiClient
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
+import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.http.HttpStatus
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@ConfigurationProperties(prefix = "tourapi.sync")
+data class TourApiSyncProperties(
+    val enabled: Boolean = true,
+    val areaCode: String = "34",
+    val contentTypeIds: List<String> = listOf("12", "14", "15", "28", "32", "38", "39"),
+    val numOfRows: Int = 100,
+    val maxPages: Int = 1,
+    val retryMaxAttempts: Int = 3,
+    val retryBackoffMillis: Long = 500,
+    val requestIntervalMillis: Long = 0,
+    val enrichLimit: Int = 50,
+)
 
 @Service
 class TourApiBatchService(
     private val tourApiClient: TourApiClient,
     private val placeRepository: PlaceRepository,
+    private val syncProperties: TourApiSyncProperties,
 ) {
     private val logger = KotlinLogging.logger {}
 
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "\${tourapi.sync.cron:0 0 3 * * *}")
     fun syncPlaces() {
-        runCatching { syncChungnamPlacesInternal() }
-            .onFailure { logger.warn(it) { "TourAPI daily sync failed" } }
+        if (!syncProperties.enabled) {
+            logger.info { "TourAPI scheduled sync skipped: disabled" }
+            return
+        }
+        runCatching { syncConfiguredAreaInternal(triggeredBy = "scheduled", operatorUserId = null) }
+            .onSuccess { report ->
+                if (report.totalFailed > 0) {
+                    logger.warn { "TourAPI scheduled sync completed with failures: ${report.toMap()}" }
+                } else {
+                    logger.info { "TourAPI scheduled sync completed: ${report.toMap()}" }
+                }
+            }
+            .onFailure { logger.warn(it) { "TourAPI scheduled sync failed" } }
     }
 
     @Transactional
-    fun syncChungnamPlaces(user: User): ApiResponse<Map<String, Any>> {
-        assertHostUser(user)
-        return ApiResponse.ok(syncChungnamPlacesInternal())
+    fun syncChungnamPlaces(user: User): ApiResponse<Map<String, Any?>> {
+        assertAdminUser(user)
+        val report = syncConfiguredAreaInternal(triggeredBy = "manual", operatorUserId = user.id)
+        return ApiResponse.ok(report.toMap())
     }
 
     @Transactional
-    fun enrichChungnamPlaces(user: User, limit: Int = 50): ApiResponse<Map<String, Any>> {
-        assertHostUser(user)
+    fun enrichChungnamPlaces(user: User, limit: Int = syncProperties.enrichLimit): ApiResponse<Map<String, Any?>> {
+        assertAdminUser(user)
+        val boundedLimit = limit.coerceIn(1, 200)
         val candidates = placeRepository.findByDelYn(YnFlag.N)
             .filter { needsDetailEnrichment(it) }
-            .take(limit.coerceIn(1, 200))
+            .take(boundedLimit)
         var enriched = 0
         var skipped = 0
         var failed = 0
-        candidates.forEach { place ->
+        val failures = mutableListOf<Map<String, Any>>()
+        candidates.forEachIndexed { index, place ->
             val contentTypeId = place.metadataTags?.get("contentTypeId")?.toString()
             if (contentTypeId.isNullOrBlank()) {
                 skipped += 1
-                return@forEach
+                return@forEachIndexed
             }
-            try {
-                val common = runBlocking { tourApiClient.fetchDetailCommon(place.tourApiId) }
-                val intro = runBlocking { tourApiClient.fetchDetailIntro(place.tourApiId, contentTypeId) }
+            val result = runCatching {
+                val common = retryTourApiCall("detailCommon", place.tourApiId) {
+                    runBlocking { tourApiClient.fetchDetailCommon(place.tourApiId) }
+                }
+                val intro = retryTourApiCall("detailIntro", place.tourApiId) {
+                    runBlocking { tourApiClient.fetchDetailIntro(place.tourApiId, contentTypeId) }
+                }
                 enrichPlace(place, common, intro)
-                enriched += 1
-            } catch (error: Exception) {
-                logger.warn(error) { "Failed to enrich place tourApiId=${place.tourApiId}" }
-                failed += 1
             }
+            if (result.isSuccess) {
+                enriched += 1
+            } else {
+                failed += 1
+                val error = result.exceptionOrNull()
+                logger.warn(error) { "Failed to enrich place tourApiId=${place.tourApiId}" }
+                failures += failureOf(place.tourApiId, contentTypeId, error)
+            }
+            throttleIfNeeded(index, candidates.lastIndex)
         }
-        return ApiResponse.ok(
-            mapOf(
-                "scanned" to candidates.size,
-                "enriched" to enriched,
-                "skipped" to skipped,
-                "failed" to failed,
-            )
+        val report = mapOf(
+            "triggeredBy" to "manual",
+            "operatorUserId" to user.id,
+            "scanned" to candidates.size,
+            "enriched" to enriched,
+            "skipped" to skipped,
+            "failed" to failed,
+            "failures" to failures.take(20),
         )
+        logger.info { "TourAPI enrich completed: $report" }
+        return ApiResponse.ok(report)
     }
-
 
     private fun needsDetailEnrichment(place: Place): Boolean {
         val metadata = place.metadataTags ?: return true
@@ -75,7 +116,7 @@ class TourApiBatchService(
         val sourceModified = metadata["sourceModifiedTime"]?.toString()?.filter { it.isDigit() }
         if (sourceModified.isNullOrBlank()) return false
         val sourceEpoch = parseTourApiTimestamp(sourceModified) ?: return false
-        val enrichedEpoch = runCatching { java.time.Instant.parse(enrichedAt).toEpochMilli() }.getOrNull() ?: return true
+        val enrichedEpoch = runCatching { Instant.parse(enrichedAt).toEpochMilli() }.getOrNull() ?: return true
         return sourceEpoch > enrichedEpoch
     }
 
@@ -102,7 +143,7 @@ class TourApiBatchService(
             place.admissionFee = extractAdmissionFee(intro)
         }
         val detailMetadata = mutableMapOf<String, Any>(
-            "detailEnrichedAt" to java.time.Instant.now().toString(),
+            "detailEnrichedAt" to Instant.now().toString(),
         )
         common?.get("tel")?.let { detailMetadata["tel"] = it }
         common?.get("homepage")?.let { detailMetadata["homepage"] = it }
@@ -130,52 +171,107 @@ class TourApiBatchService(
         return values.takeIf { it.isNotEmpty() }?.joinToString(" | ")
     }
 
-    private fun syncChungnamPlacesInternal(): Map<String, Any> {
-        val contentTypeIds = listOf("12", "14", "15", "28", "32", "38", "39")
-        val byType = mutableListOf<Map<String, Any>>()
-        var totalFetched = 0
-        var totalSynced = 0
-        var totalUnchanged = 0
+    private fun syncConfiguredAreaInternal(triggeredBy: String, operatorUserId: Long?): TourApiSyncReport {
+        val startedAt = Instant.now()
+        val byType = syncProperties.contentTypeIds.map { contentTypeId ->
+            syncContentType(contentTypeId)
+        }
+        val report = TourApiSyncReport(
+            areaCode = syncProperties.areaCode,
+            contentTypeIds = syncProperties.contentTypeIds,
+            triggeredBy = triggeredBy,
+            operatorUserId = operatorUserId,
+            startedAt = startedAt.toString(),
+            finishedAt = Instant.now().toString(),
+            byType = byType,
+        )
+        logger.info { "TourAPI sync summary: ${report.toMap()}" }
+        return report
+    }
 
-        contentTypeIds.forEach { contentTypeId ->
-            val fetched = runBlocking { tourApiClient.fetchAreaBasedList(contentTypeId = contentTypeId) }
-            var synced = 0
-            var unchanged = 0
+    private fun syncContentType(contentTypeId: String): TourApiContentTypeReport {
+        var totalFetched = 0
+        var created = 0
+        var updated = 0
+        var unchanged = 0
+        var failed = 0
+        val failures = mutableListOf<Map<String, Any>>()
+
+        for (pageNo in 1..syncProperties.maxPages.coerceAtLeast(1)) {
+            val fetched = runCatching {
+                retryTourApiCall("areaBasedList", "contentTypeId=$contentTypeId,page=$pageNo") {
+                    runBlocking {
+                        tourApiClient.fetchAreaBasedList(
+                            areaCode = syncProperties.areaCode,
+                            pageNo = pageNo,
+                            contentTypeId = contentTypeId,
+                            numOfRows = syncProperties.numOfRows,
+                        )
+                    }
+                }
+            }.getOrElse { error ->
+                failed += 1
+                logger.warn(error) { "TourAPI sync page failed contentTypeId=$contentTypeId pageNo=$pageNo" }
+                failures += failureOf("page=$pageNo", contentTypeId, error)
+                emptyList()
+            }
+
+            totalFetched += fetched.size
             fetched.forEach { incoming ->
-                val existing = placeRepository.findByTourApiId(incoming.tourApiId)
-                if (existing == null) {
-                    placeRepository.save(incoming)
-                    synced += 1
-                } else if (mergePlace(existing, incoming)) {
-                    synced += 1
-                } else {
-                    unchanged += 1
+                val result = runCatching {
+                    val existing = placeRepository.findByTourApiId(incoming.tourApiId)
+                    when {
+                        existing == null -> {
+                            incoming.metadataTags = operationMetadata(incoming.metadataTags, contentTypeId, markSyncedAt = true)
+                            placeRepository.save(incoming)
+                            created += 1
+                        }
+                        mergePlace(existing, incoming, contentTypeId) -> {
+                            placeRepository.save(existing)
+                            updated += 1
+                        }
+                        else -> unchanged += 1
+                    }
+                }
+                if (result.isFailure) {
+                    failed += 1
+                    val error = result.exceptionOrNull()
+                    logger.warn(error) { "TourAPI place upsert failed tourApiId=${incoming.tourApiId}" }
+                    failures += failureOf(incoming.tourApiId, contentTypeId, error)
                 }
             }
-            totalFetched += fetched.size
-            totalSynced += synced
-            totalUnchanged += unchanged
-            byType += mapOf(
-                "contentTypeId" to contentTypeId.toInt(),
-                "totalCount" to fetched.size,
-                "synced" to synced,
-                "skipped" to 0,
-                "unchanged" to unchanged,
-            )
+            throttleIfNeeded(pageNo, syncProperties.maxPages)
+            if (fetched.size < syncProperties.numOfRows) break
         }
 
-        return mapOf(
-            "areaCode" to 34,
-            "contentTypeIds" to contentTypeIds.map { it.toInt() },
-            "totalFetched" to totalFetched,
-            "totalSynced" to totalSynced,
-            "totalSkipped" to 0,
-            "totalUnchanged" to totalUnchanged,
-            "byType" to byType,
+        return TourApiContentTypeReport(
+            contentTypeId = contentTypeId,
+            totalFetched = totalFetched,
+            created = created,
+            updated = updated,
+            unchanged = unchanged,
+            failed = failed,
+            failures = failures.take(20),
         )
     }
 
-    private fun mergePlace(existing: Place, incoming: Place): Boolean {
+    private fun <T> retryTourApiCall(operation: String, target: String, block: () -> T): T {
+        val maxAttempts = syncProperties.retryMaxAttempts.coerceAtLeast(1)
+        var lastError: Throwable? = null
+        repeat(maxAttempts) { attemptIndex ->
+            try {
+                return block()
+            } catch (error: Throwable) {
+                lastError = error
+                val attempt = attemptIndex + 1
+                logger.warn(error) { "TourAPI $operation failed target=$target attempt=$attempt/$maxAttempts" }
+                if (attempt < maxAttempts) sleepQuietly(syncProperties.retryBackoffMillis * attempt)
+            }
+        }
+        throw lastError ?: IllegalStateException("TourAPI $operation failed target=$target")
+    }
+
+    private fun mergePlace(existing: Place, incoming: Place, contentTypeId: String): Boolean {
         var changed = false
         fun <T> update(current: T, next: T, setter: (T) -> Unit) {
             if (current != next) {
@@ -189,14 +285,107 @@ class TourApiBatchService(
         update(existing.longitude, incoming.longitude) { existing.longitude = it }
         update(existing.category, incoming.category) { existing.category = it }
         update(existing.imageUrl, incoming.imageUrl) { existing.imageUrl = it }
-        update(existing.metadataTags, incoming.metadataTags) { existing.metadataTags = it }
-        existing.delYn = YnFlag.N
+        val nextMetadata = operationMetadata(
+            metadata = (existing.metadataTags ?: emptyMap()) + (incoming.metadataTags ?: emptyMap()),
+            contentTypeId = contentTypeId,
+            markSyncedAt = false,
+        )
+        update(existing.metadataTags, nextMetadata) { existing.metadataTags = it }
+        if (existing.delYn != YnFlag.N) {
+            existing.delYn = YnFlag.N
+            changed = true
+        }
+        if (changed) {
+            existing.metadataTags = operationMetadata(existing.metadataTags, contentTypeId, markSyncedAt = true)
+        }
         return changed
     }
 
-    private fun assertHostUser(user: User) {
-        if (user.isGuest) {
-            throw DomainException(HttpStatus.FORBIDDEN, "FORBIDDEN", "방장 권한이 필요합니다.")
+    private fun operationMetadata(metadata: Map<String, Any>?, contentTypeId: String, markSyncedAt: Boolean): Map<String, Any> {
+        val base = (metadata ?: emptyMap()) + mapOf(
+            "contentTypeId" to contentTypeId,
+            "source" to "TourAPI",
+            "sourceAreaCode" to syncProperties.areaCode,
+        )
+        return if (markSyncedAt) base + ("lastSyncedAt" to Instant.now().toString()) else base
+    }
+
+    private fun failureOf(target: String, contentTypeId: String, error: Throwable?): Map<String, Any> {
+        return mapOf(
+            "target" to target,
+            "contentTypeId" to contentTypeId,
+            "errorType" to (error?.javaClass?.simpleName ?: "Unknown"),
+            "message" to (error?.message ?: ""),
+        )
+    }
+
+    private fun throttleIfNeeded(index: Int, lastIndex: Int) {
+        if (index < lastIndex) sleepQuietly(syncProperties.requestIntervalMillis)
+    }
+
+    private fun sleepQuietly(millis: Long) {
+        if (millis <= 0) return
+        runCatching { Thread.sleep(millis) }
+            .onFailure { Thread.currentThread().interrupt() }
+    }
+
+    private fun assertAdminUser(user: User) {
+        if (user.isGuest || user.adminYn != YnFlag.Y) {
+            throw DomainException(HttpStatus.FORBIDDEN, "FORBIDDEN", "관리자 권한이 필요합니다.")
         }
     }
+}
+
+data class TourApiSyncReport(
+    val areaCode: String,
+    val contentTypeIds: List<String>,
+    val triggeredBy: String,
+    val operatorUserId: Long?,
+    val startedAt: String,
+    val finishedAt: String,
+    val byType: List<TourApiContentTypeReport>,
+) {
+    val totalFetched: Int = byType.sumOf { it.totalFetched }
+    val totalCreated: Int = byType.sumOf { it.created }
+    val totalUpdated: Int = byType.sumOf { it.updated }
+    val totalSynced: Int = totalCreated + totalUpdated
+    val totalUnchanged: Int = byType.sumOf { it.unchanged }
+    val totalFailed: Int = byType.sumOf { it.failed }
+
+    fun toMap(): Map<String, Any?> = mapOf(
+        "areaCode" to areaCode,
+        "contentTypeIds" to contentTypeIds.mapNotNull { it.toIntOrNull() },
+        "triggeredBy" to triggeredBy,
+        "operatorUserId" to operatorUserId,
+        "startedAt" to startedAt,
+        "finishedAt" to finishedAt,
+        "totalFetched" to totalFetched,
+        "totalCreated" to totalCreated,
+        "totalUpdated" to totalUpdated,
+        "totalSynced" to totalSynced,
+        "totalUnchanged" to totalUnchanged,
+        "totalFailed" to totalFailed,
+        "byType" to byType.map { it.toMap() },
+    )
+}
+
+data class TourApiContentTypeReport(
+    val contentTypeId: String,
+    val totalFetched: Int,
+    val created: Int,
+    val updated: Int,
+    val unchanged: Int,
+    val failed: Int,
+    val failures: List<Map<String, Any>>,
+) {
+    fun toMap(): Map<String, Any> = mapOf(
+        "contentTypeId" to (contentTypeId.toIntOrNull() ?: contentTypeId),
+        "totalFetched" to totalFetched,
+        "created" to created,
+        "updated" to updated,
+        "synced" to created + updated,
+        "unchanged" to unchanged,
+        "failed" to failed,
+        "failures" to failures,
+    )
 }

--- a/src/main/kotlin/com/tripsync/infrastructure/tourapi/TourApiClient.kt
+++ b/src/main/kotlin/com/tripsync/infrastructure/tourapi/TourApiClient.kt
@@ -3,7 +3,6 @@ package com.tripsync.infrastructure.tourapi
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.tripsync.domain.entity.Place
-import com.tripsync.domain.repository.PlaceRepository
 import kotlinx.coroutines.reactive.awaitSingle
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
@@ -16,7 +15,6 @@ import java.math.BigDecimal
 class TourApiClient(
     private val webClient: WebClient,
     private val objectMapper: ObjectMapper,
-    private val placeRepository: PlaceRepository,
     @Value("\${tourapi.key:}")
     private val apiKey: String,
     @Value("\${tourapi.base-url:https://apis.data.go.kr/B551011/KorService2}")
@@ -30,7 +28,7 @@ class TourApiClient(
 ) {
     private val logger = KotlinLogging.logger {}
 
-    suspend fun fetchAreaBasedList(areaCode: String = "34", sigunguCode: String? = null, pageNo: Int = 1, contentTypeId: String? = null): List<Place> {
+    suspend fun fetchAreaBasedList(areaCode: String = "34", sigunguCode: String? = null, pageNo: Int = 1, contentTypeId: String? = null, numOfRows: Int = 100): List<Place> {
         if (apiKey.isBlank()) {
             logger.warn { "TourAPI key not configured" }
             return emptyList()
@@ -38,7 +36,7 @@ class TourApiClient(
 
         val uriBuilder = org.springframework.web.util.UriComponentsBuilder.fromHttpUrl("$baseUrl/areaBasedList2")
             .queryParam("serviceKey", apiKey)
-            .queryParam("numOfRows", 100)
+            .queryParam("numOfRows", numOfRows.coerceIn(1, 500))
             .queryParam("pageNo", pageNo)
             .queryParam("MobileOS", mobileOs)
             .queryParam("MobileApp", mobileApp)
@@ -109,9 +107,8 @@ class TourApiClient(
 
     private fun parsePlace(item: JsonNode): Place {
         val contentId = item.path("contentid").asText()
-        val existing = placeRepository.findByTourApiId(contentId)
 
-        val place = existing ?: Place(
+        val place = Place(
             tourApiId = contentId,
             name = item.path("title").asText(),
             address = item.path("addr1").asText(""),
@@ -127,6 +124,11 @@ class TourApiClient(
                 "contentTypeId" to item.path("contenttypeid").asText(),
                 "areaCode" to item.path("areacode").asText(),
                 "sigunguCode" to item.path("sigungucode").asText(),
+                "sourceCreatedTime" to item.path("createdtime").asText(),
+                "sourceModifiedTime" to item.path("modifiedtime").asText(),
+                "categoryCode1" to item.path("cat1").asText(),
+                "categoryCode2" to item.path("cat2").asText(),
+                "categoryCode3" to item.path("cat3").asText(),
             ),
         )
 

--- a/src/main/kotlin/com/tripsync/web/tourapi/TourApiController.kt
+++ b/src/main/kotlin/com/tripsync/web/tourapi/TourApiController.kt
@@ -17,7 +17,7 @@ class TourApiController(
     private val tourApiBatchService: TourApiBatchService,
 ) {
     @PostMapping("/sync/chungnam")
-    fun syncChungnam(@CurrentUser user: User): ApiResponse<Map<String, Any>> {
+    fun syncChungnam(@CurrentUser user: User): ApiResponse<Map<String, Any?>> {
         return tourApiBatchService.syncChungnamPlaces(user)
     }
 
@@ -25,7 +25,7 @@ class TourApiController(
     fun enrichChungnam(
         @RequestBody(required = false) dto: EnrichPlacesDto?,
         @CurrentUser user: User,
-    ): ApiResponse<Map<String, Any>> {
+    ): ApiResponse<Map<String, Any?>> {
         return tourApiBatchService.enrichChungnamPlaces(user, dto?.limit ?: 50)
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -66,6 +66,17 @@ tourapi:
   mobile-os: ${TOUR_API_MOBILE_OS:ETC}
   mobile-app: ${TOUR_API_MOBILE_APP:TripSync}
   response-type: ${TOUR_API_RESPONSE_TYPE:json}
+  sync:
+    enabled: ${TOUR_API_SYNC_ENABLED:true}
+    cron: ${TOUR_API_SYNC_CRON:0 0 3 * * *}
+    area-code: ${TOUR_API_SYNC_AREA_CODE:34}
+    content-type-ids: ${TOUR_API_SYNC_CONTENT_TYPE_IDS:12,14,15,28,32,38,39}
+    num-of-rows: ${TOUR_API_SYNC_NUM_OF_ROWS:100}
+    max-pages: ${TOUR_API_SYNC_MAX_PAGES:1}
+    retry-max-attempts: ${TOUR_API_SYNC_RETRY_MAX_ATTEMPTS:3}
+    retry-backoff-millis: ${TOUR_API_SYNC_RETRY_BACKOFF_MILLIS:500}
+    request-interval-millis: ${TOUR_API_SYNC_REQUEST_INTERVAL_MILLIS:0}
+    enrich-limit: ${TOUR_API_ENRICH_LIMIT:50}
 
 api:
   base-url: ${API_BASE_URL:http://localhost:8080/api}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,17 @@ tourapi:
   mobile-os: ${TOUR_API_MOBILE_OS:ETC}
   mobile-app: ${TOUR_API_MOBILE_APP:TripSync}
   response-type: ${TOUR_API_RESPONSE_TYPE:json}
+  sync:
+    enabled: ${TOUR_API_SYNC_ENABLED:true}
+    cron: ${TOUR_API_SYNC_CRON:0 0 3 * * *}
+    area-code: ${TOUR_API_SYNC_AREA_CODE:34}
+    content-type-ids: ${TOUR_API_SYNC_CONTENT_TYPE_IDS:12,14,15,28,32,38,39}
+    num-of-rows: ${TOUR_API_SYNC_NUM_OF_ROWS:100}
+    max-pages: ${TOUR_API_SYNC_MAX_PAGES:1}
+    retry-max-attempts: ${TOUR_API_SYNC_RETRY_MAX_ATTEMPTS:3}
+    retry-backoff-millis: ${TOUR_API_SYNC_RETRY_BACKOFF_MILLIS:500}
+    request-interval-millis: ${TOUR_API_SYNC_REQUEST_INTERVAL_MILLIS:0}
+    enrich-limit: ${TOUR_API_ENRICH_LIMIT:50}
 
 api:
   base-url: ${API_BASE_URL:http://localhost:8080/api}

--- a/src/test/kotlin/com/tripsync/application/tourapi/TourApiBatchServiceTest.kt
+++ b/src/test/kotlin/com/tripsync/application/tourapi/TourApiBatchServiceTest.kt
@@ -1,0 +1,172 @@
+package com.tripsync.application.tourapi
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.tripsync.common.exception.DomainException
+import com.tripsync.domain.entity.Place
+import com.tripsync.domain.entity.User
+import com.tripsync.domain.enums.AuthProvider
+import com.tripsync.domain.enums.YnFlag
+import com.tripsync.domain.repository.PlaceRepository
+import com.tripsync.infrastructure.tourapi.TourApiClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.web.reactive.function.client.WebClient
+import java.math.BigDecimal
+
+class TourApiBatchServiceTest {
+    @Test
+    fun `manual sync requires admin user`() {
+        val service = service()
+        val user = User(
+            nickname = "member",
+            authProvider = AuthProvider.LOCAL,
+            isGuest = false,
+            adminYn = YnFlag.N,
+        )
+
+        val error = assertThrows(DomainException::class.java) {
+            service.syncChungnamPlaces(user)
+        }
+
+        assertEquals("FORBIDDEN", error.code)
+    }
+
+    @Test
+    fun `manual sync returns operation report for admin user`() {
+        val service = service()
+        val admin = User(
+            id = 7,
+            nickname = "admin",
+            authProvider = AuthProvider.LOCAL,
+            adminYn = YnFlag.Y,
+        )
+
+        val report = service.syncChungnamPlaces(admin).data!!
+        val byType = report["byType"] as List<*>
+
+        assertEquals("manual", report["triggeredBy"])
+        assertEquals(7L, report["operatorUserId"])
+        assertEquals(0, report["totalFetched"])
+        assertEquals(0, report["totalFailed"])
+        assertEquals(1, byType.size)
+        assertTrue(report.containsKey("startedAt"))
+        assertTrue(report.containsKey("finishedAt"))
+    }
+
+
+    @Test
+    fun `unchanged place merge does not update sync timestamp`() {
+        val service = service()
+        val existing = place(
+            tourApiId = "same-1",
+            name = "같은 장소",
+            metadataTags = mapOf(
+                "contentTypeId" to "12",
+                "source" to "TourAPI",
+                "sourceAreaCode" to "34",
+                "lastSyncedAt" to "2026-01-01T00:00:00Z",
+            ),
+        )
+        val incoming = place(
+            tourApiId = "same-1",
+            name = "같은 장소",
+            metadataTags = mapOf(
+                "contentTypeId" to "12",
+                "source" to "TourAPI",
+                "sourceAreaCode" to "34",
+            ),
+        )
+
+        val changed = invokeMergePlace(service, existing, incoming, "12")
+
+        assertEquals(false, changed)
+        assertEquals("2026-01-01T00:00:00Z", existing.metadataTags?.get("lastSyncedAt"))
+    }
+
+    @Test
+    fun `changed place merge preserves detail metadata and updates sync timestamp`() {
+        val service = service()
+        val existing = place(
+            tourApiId = "changed-1",
+            name = "기존 장소",
+            metadataTags = mapOf(
+                "contentTypeId" to "12",
+                "detailEnrichedAt" to "2026-01-01T00:00:00Z",
+                "lastSyncedAt" to "2026-01-01T00:00:00Z",
+            ),
+        )
+        val incoming = place(
+            tourApiId = "changed-1",
+            name = "변경 장소",
+            metadataTags = mapOf("sourceModifiedTime" to "20260517090000"),
+        )
+
+        val changed = invokeMergePlace(service, existing, incoming, "12")
+
+        assertEquals(true, changed)
+        assertEquals("변경 장소", existing.name)
+        assertEquals("2026-01-01T00:00:00Z", existing.metadataTags?.get("detailEnrichedAt"))
+        assertEquals("20260517090000", existing.metadataTags?.get("sourceModifiedTime"))
+        assertTrue(existing.metadataTags?.get("lastSyncedAt") != "2026-01-01T00:00:00Z")
+    }
+
+    private fun service(): TourApiBatchService {
+        val placeRepository = mock(PlaceRepository::class.java)
+        val client = TourApiClient(
+            webClient = WebClient.create(),
+            objectMapper = ObjectMapper(),
+            apiKey = "",
+            baseUrl = "https://example.invalid",
+            mobileOs = "ETC",
+            mobileApp = "TripSyncTest",
+            responseType = "json",
+        )
+        return TourApiBatchService(
+            tourApiClient = client,
+            placeRepository = placeRepository,
+            syncProperties = TourApiSyncProperties(
+                contentTypeIds = listOf("12"),
+                maxPages = 1,
+                retryMaxAttempts = 1,
+                requestIntervalMillis = 0,
+            ),
+        )
+    }
+
+    private fun invokeMergePlace(
+        service: TourApiBatchService,
+        existing: Place,
+        incoming: Place,
+        contentTypeId: String,
+    ): Boolean {
+        val method = TourApiBatchService::class.java.getDeclaredMethod(
+            "mergePlace",
+            Place::class.java,
+            Place::class.java,
+            String::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(service, existing, incoming, contentTypeId) as Boolean
+    }
+
+    private fun place(tourApiId: String, name: String, metadataTags: Map<String, Any>): Place {
+        return Place(
+            tourApiId = tourApiId,
+            name = name,
+            address = "충청남도 테스트군",
+            latitude = BigDecimal("36.5000000"),
+            longitude = BigDecimal("126.5000000"),
+            category = "tourist_attraction",
+            imageUrl = "",
+            mobilityScore = 50,
+            photoScore = 50,
+            budgetScore = 50,
+            themeScore = 50,
+            metadataTags = metadataTags,
+        )
+    }
+
+}

--- a/src/test/kotlin/com/tripsync/infrastructure/tourapi/TourApiClientTest.kt
+++ b/src/test/kotlin/com/tripsync/infrastructure/tourapi/TourApiClientTest.kt
@@ -1,0 +1,62 @@
+package com.tripsync.infrastructure.tourapi
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.tripsync.domain.entity.Place
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+
+class TourApiClientTest {
+    private val objectMapper = ObjectMapper()
+
+    @Test
+    fun `parse place creates api response snapshot every time`() {
+        val client = TourApiClient(
+            webClient = WebClient.create(),
+            objectMapper = objectMapper,
+            apiKey = "",
+            baseUrl = "https://example.invalid",
+            mobileOs = "ETC",
+            mobileApp = "TripSyncTest",
+            responseType = "json",
+        )
+        val first = invokeParsePlace(client, item(title = "기존 이름"))
+        val second = invokeParsePlace(client, item(title = "변경 이름", modifiedTime = "20260517090000"))
+
+        assertNotSame(first, second)
+        assertEquals("기존 이름", first.name)
+        assertEquals("변경 이름", second.name)
+        assertEquals("20260517090000", second.metadataTags?.get("sourceModifiedTime"))
+    }
+
+    private fun invokeParsePlace(client: TourApiClient, item: JsonNode): Place {
+        val method = TourApiClient::class.java.getDeclaredMethod("parsePlace", JsonNode::class.java)
+        method.isAccessible = true
+        return method.invoke(client, item) as Place
+    }
+
+    private fun item(title: String, modifiedTime: String = "20260516090000"): JsonNode {
+        return objectMapper.readTree(
+            """
+            {
+              "contentid": "tour-1",
+              "title": "$title",
+              "addr1": "충청남도 테스트군",
+              "mapy": "36.5000000",
+              "mapx": "126.5000000",
+              "contenttypeid": "12",
+              "firstimage": "https://example.invalid/image.jpg",
+              "areacode": "34",
+              "sigungucode": "1",
+              "createdtime": "20260515090000",
+              "modifiedtime": "$modifiedTime",
+              "cat1": "A01",
+              "cat2": "A0101",
+              "cat3": "A01010100"
+            }
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- TourAPI 동기화 운영화

## Changes

- TourAPI sync 설정값 추가
- scheduled sync enable/cron/대상 content type 설정화
- 수동 sync/enrich 관리자 권한 검증 강화
- TourAPI 호출 retry/backoff/throttle 적용
- content type/page/place 단위 부분 실패 집계 추가
- sync/enrich 운영 요약 로그 및 응답 추가
- TourAPI source metadata 병합 정책 보강
- 변경 없는 장소 merge timestamp 유지 회귀 테스트 추가

## Verification

- [ ] Not run
- [ ] Build
- [x] Test: `./gradlew test --rerun-tasks --no-daemon`
- [ ] Manual

## Notes

- 실제 TourAPI 운영 key/rate limit 환경은 미검증
