### PR TITLE
fix: 일반 멤버 방 탈퇴 처리

### DIFF
--- a/src/main/kotlin/com/tripsync/application/room/RoomService.kt
+++ b/src/main/kotlin/com/tripsync/application/room/RoomService.kt
@@ -14,6 +14,7 @@ import com.tripsync.domain.repository.*
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 
@@ -24,6 +25,10 @@ class RoomService(
     private val roomMemberProfileRepository: RoomMemberProfileRepository,
     private val tptiResultRepository: TptiResultRepository,
     private val scheduleRepository: ScheduleRepository,
+    private val scheduleSlotRepository: ScheduleSlotRepository,
+    private val satisfactionScoreRepository: SatisfactionScoreRepository,
+    private val conflictMapRepository: ConflictMapRepository,
+    private val tripPhotoRepository: TripPhotoRepository,
     private val scheduleResponseMapper: ScheduleResponseMapper,
 ) {
 
@@ -71,8 +76,8 @@ class RoomService(
 
     @Transactional(readOnly = true)
     fun getRoom(roomId: Long, user: User): ApiResponse<Map<String, Any?>> {
-        validateRoomMember(roomId, user.id)
         val room = getActiveRoom(roomId)
+        validateRoomMember(room.id, user.id)
         val memberCount = roomMemberRepository.findAllByRoomIdAndDelYn(room.id, YnFlag.N).size
 
         return ApiResponse.ok(roomSummary(room, memberCount, includeScheduleState = true))
@@ -116,7 +121,7 @@ class RoomService(
         val room = tripRoomRepository.findByShareCodeAndDelYn(shareCode, YnFlag.N)
             ?: throw DomainException(HttpStatus.NOT_FOUND, "INVALID_SHARE_CODE", "유효하지 않은 공유 코드입니다.")
 
-        val existingMember = roomMemberRepository.findByRoomIdAndUserIdAndDelYn(room.id, user.id, YnFlag.N)
+        val existingMember = roomMemberRepository.findByRoomIdAndUserId(room.id, user.id)
         if (existingMember == null) {
             roomMemberRepository.save(
                 RoomMember(
@@ -125,6 +130,9 @@ class RoomService(
                     role = if (room.hostUser.id == user.id) RoomMemberRole.HOST else RoomMemberRole.MEMBER,
                 )
             )
+        } else {
+            existingMember.delYn = YnFlag.N
+            existingMember.role = if (room.hostUser.id == user.id) RoomMemberRole.HOST else existingMember.role
         }
 
         if (tptiResultId != null) {
@@ -135,7 +143,7 @@ class RoomService(
             upsertMemberProfile(room, user, result)
         }
 
-        val roomStatus = refreshRoomStatus(room.id)
+        val roomStatus = if (room.status == TripRoomStatus.COMPLETED) room.status else refreshRoomStatus(room.id)
         return ApiResponse.ok(
             mapOf(
                 "roomId" to room.id,
@@ -148,14 +156,15 @@ class RoomService(
 
     @Transactional(readOnly = true)
     fun getMembers(roomId: Long, user: User): ApiResponse<Map<String, Any?>> {
-        validateRoomMember(roomId, user.id)
-        val members = roomMemberRepository.findAllByRoomIdAndDelYn(roomId, YnFlag.N)
-        val profilesByUserId = roomMemberProfileRepository.findAllByRoomIdAndDelYn(roomId, YnFlag.N)
+        val room = getActiveRoom(roomId)
+        validateRoomMember(room.id, user.id)
+        val members = roomMemberRepository.findAllByRoomIdAndDelYn(room.id, YnFlag.N)
+        val profilesByUserId = roomMemberProfileRepository.findAllByRoomIdAndDelYn(room.id, YnFlag.N)
             .associateBy { it.user.id }
 
         return ApiResponse.ok(
             mapOf(
-                "roomId" to roomId,
+                "roomId" to room.id,
                 "members" to members.sortedBy { it.joinedAt }.map { member ->
                     val profile = profilesByUserId[member.user.id]
                     mapOf(
@@ -176,6 +185,52 @@ class RoomService(
                 },
             )
         )
+    }
+
+    @Transactional
+    fun deleteRoom(roomId: Long, user: User): ApiResponse<Map<String, Any?>> {
+        if (user.isGuest) {
+            throw DomainException(HttpStatus.FORBIDDEN, "FORBIDDEN", "로그인한 계정으로만 여행 방을 삭제하거나 나갈 수 있습니다.")
+        }
+
+        val room = getActiveRoom(roomId)
+        val member = roomMemberRepository.findByRoomIdAndUserIdAndDelYn(room.id, user.id, YnFlag.N)
+            ?: throw DomainException(HttpStatus.FORBIDDEN, "FORBIDDEN", "방 멤버만 여행 방을 삭제하거나 나갈 수 있습니다.")
+
+        if (member.role != RoomMemberRole.HOST) {
+            return leaveRoom(room, member)
+        }
+
+        val schedules = scheduleRepository.findByRoomIdAndDelYn(room.id, YnFlag.N)
+        schedules.forEach { schedule ->
+            satisfactionScoreRepository.findAllByScheduleIdAndDelYn(schedule.id, YnFlag.N).forEach { it.delYn = YnFlag.Y }
+            scheduleSlotRepository.findAllByScheduleIdAndDelYn(schedule.id, YnFlag.N).forEach { it.delYn = YnFlag.Y }
+            schedule.delYn = YnFlag.Y
+        }
+
+        val deletedAt = Instant.now()
+        tripPhotoRepository.findAllByRoomIdAndDelYn(room.id, YnFlag.N).forEach { photo ->
+            photo.delYn = YnFlag.Y
+            photo.deletedBy = user
+            photo.deletedAt = deletedAt
+        }
+        conflictMapRepository.findAllByRoomIdAndDelYn(room.id, YnFlag.N).forEach { it.delYn = YnFlag.Y }
+        roomMemberProfileRepository.findAllByRoomIdAndDelYn(room.id, YnFlag.N).forEach { it.delYn = YnFlag.Y }
+        roomMemberRepository.findAllByRoomIdAndDelYn(room.id, YnFlag.N).forEach { it.delYn = YnFlag.Y }
+        room.delYn = YnFlag.Y
+
+        return ApiResponse.ok(mapOf("roomId" to room.id, "deleted" to true, "left" to false))
+    }
+
+    private fun leaveRoom(room: TripRoom, member: RoomMember): ApiResponse<Map<String, Any?>> {
+        member.delYn = YnFlag.Y
+        roomMemberProfileRepository.findByRoomIdAndUserId(room.id, member.user.id)?.delYn = YnFlag.Y
+        satisfactionScoreRepository.findAllByScheduleRoomIdAndUserIdAndDelYn(room.id, member.user.id, YnFlag.N)
+            .forEach { it.delYn = YnFlag.Y }
+        if (room.status != TripRoomStatus.COMPLETED) {
+            refreshRoomStatus(room.id)
+        }
+        return ApiResponse.ok(mapOf("roomId" to room.id, "deleted" to false, "left" to true))
     }
 
 

--- a/src/main/kotlin/com/tripsync/domain/repository/ConflictMapRepository.kt
+++ b/src/main/kotlin/com/tripsync/domain/repository/ConflictMapRepository.kt
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ConflictMapRepository : JpaRepository<ConflictMap, Long> {
     fun findTopByRoomIdAndDelYnOrderByCreatedAtDesc(roomId: Long, delYn: YnFlag): ConflictMap?
+    fun findAllByRoomIdAndDelYn(roomId: Long, delYn: YnFlag): List<ConflictMap>
 }

--- a/src/main/kotlin/com/tripsync/domain/repository/RoomMemberRepository.kt
+++ b/src/main/kotlin/com/tripsync/domain/repository/RoomMemberRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface RoomMemberRepository : JpaRepository<RoomMember, Long> {
+    fun findByRoomIdAndUserId(roomId: Long, userId: Long): RoomMember?
     fun findByRoomIdAndUserIdAndDelYn(roomId: Long, userId: Long, delYn: YnFlag): RoomMember?
     fun existsByRoomIdAndUserIdAndDelYn(roomId: Long, userId: Long, delYn: YnFlag): Boolean
     fun findAllByRoomIdAndDelYn(roomId: Long, delYn: YnFlag): List<RoomMember>

--- a/src/main/kotlin/com/tripsync/domain/repository/SatisfactionScoreRepository.kt
+++ b/src/main/kotlin/com/tripsync/domain/repository/SatisfactionScoreRepository.kt
@@ -1,8 +1,12 @@
 package com.tripsync.domain.repository
 
 import com.tripsync.domain.entity.SatisfactionScore
+import com.tripsync.domain.enums.YnFlag
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface SatisfactionScoreRepository : JpaRepository<SatisfactionScore, Long>
+interface SatisfactionScoreRepository : JpaRepository<SatisfactionScore, Long> {
+    fun findAllByScheduleIdAndDelYn(scheduleId: Long, delYn: YnFlag): List<SatisfactionScore>
+    fun findAllByScheduleRoomIdAndUserIdAndDelYn(roomId: Long, userId: Long, delYn: YnFlag): List<SatisfactionScore>
+}

--- a/src/main/kotlin/com/tripsync/domain/repository/TripPhotoRepository.kt
+++ b/src/main/kotlin/com/tripsync/domain/repository/TripPhotoRepository.kt
@@ -47,6 +47,8 @@ interface TripPhotoRepository : JpaRepository<TripPhoto, Long> {
         status: PhotoStatus,
     ): List<TripPhoto>
 
+    fun findAllByRoomIdAndDelYn(roomId: Long, delYn: YnFlag): List<TripPhoto>
+
     fun countByScheduleIdAndDelYnAndStatus(scheduleId: Long, delYn: YnFlag, status: PhotoStatus): Long
     fun countByScheduleSlotIdAndDelYnAndStatus(scheduleSlotId: Long, delYn: YnFlag, status: PhotoStatus): Long
     fun countByScheduleIdAndUploaderIdAndDelYnAndStatus(scheduleId: Long, uploaderId: Long, delYn: YnFlag, status: PhotoStatus): Long

--- a/src/main/kotlin/com/tripsync/web/room/RoomController.kt
+++ b/src/main/kotlin/com/tripsync/web/room/RoomController.kt
@@ -58,6 +58,11 @@ class RoomController(
         return roomService.getMembers(roomId, user)
     }
 
+    @DeleteMapping("/{roomId}")
+    fun deleteRoom(@PathVariable roomId: Long, @CurrentUser user: User): ApiResponse<Map<String, Any?>> {
+        return roomService.deleteRoom(roomId, user)
+    }
+
     @GetMapping("/{roomId}")
     fun getRoom(@PathVariable roomId: Long, @CurrentUser user: User): ApiResponse<Map<String, Any?>> {
         return roomService.getRoom(roomId, user)

--- a/src/test/kotlin/com/tripsync/AuthContractTests.kt
+++ b/src/test/kotlin/com/tripsync/AuthContractTests.kt
@@ -1,7 +1,26 @@
 package com.tripsync
 
+import com.tripsync.domain.entity.Place
+import com.tripsync.domain.entity.SatisfactionScore
+import com.tripsync.domain.entity.Schedule
+import com.tripsync.domain.entity.ScheduleSlot
+import com.tripsync.domain.entity.TripPhoto
+import com.tripsync.domain.enums.PhotoStatus
+import com.tripsync.domain.enums.ReasonAxis
+import com.tripsync.domain.enums.ScheduleOptionType
+import com.tripsync.domain.enums.SlotType
+import com.tripsync.domain.enums.TripRoomStatus
+import com.tripsync.domain.enums.YnFlag
+import com.tripsync.domain.repository.PlaceRepository
+import com.tripsync.domain.repository.SatisfactionScoreRepository
+import com.tripsync.domain.repository.ScheduleRepository
+import com.tripsync.domain.repository.ScheduleSlotRepository
+import com.tripsync.domain.repository.TripPhotoRepository
+import com.tripsync.domain.repository.TripRoomRepository
+import com.tripsync.domain.repository.UserRepository
 import org.hamcrest.Matchers.notNullValue
 import org.hamcrest.Matchers.startsWith
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -9,9 +28,12 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import java.math.BigDecimal
 import java.net.URLDecoder
+import java.time.Instant
 import java.time.LocalDate
 import java.nio.charset.StandardCharsets
 
@@ -20,6 +42,13 @@ import java.nio.charset.StandardCharsets
 @ActiveProfiles("test")
 class AuthContractTests(
     @Autowired private val mockMvc: MockMvc,
+    @Autowired private val userRepository: UserRepository,
+    @Autowired private val tripRoomRepository: TripRoomRepository,
+    @Autowired private val placeRepository: PlaceRepository,
+    @Autowired private val scheduleRepository: ScheduleRepository,
+    @Autowired private val scheduleSlotRepository: ScheduleSlotRepository,
+    @Autowired private val satisfactionScoreRepository: SatisfactionScoreRepository,
+    @Autowired private val tripPhotoRepository: TripPhotoRepository,
 ) {
     @Test
     fun `guest session returns Nest-compatible user payload and session cookie`() {
@@ -348,6 +377,91 @@ class AuthContractTests(
             }
     }
 
+    @Test
+    fun `host can delete own room and it disappears from room entry points`() {
+        val hostSession = registerSession("host-delete-room@example.com", "삭제방장")
+        val payload = createRoomPayload(hostSession)
+
+        mockMvc.delete("/rooms/${payload.roomId}") { cookie(hostSession) }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.roomId") { value(payload.roomId.toInt()) }
+                jsonPath("$.data.deleted") { value(true) }
+            }
+
+        mockMvc.get("/rooms/my") { cookie(hostSession) }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data.rooms.length()") { value(0) }
+            }
+
+        mockMvc.get("/rooms/${payload.roomId}") { cookie(hostSession) }
+            .andExpect {
+                status { isNotFound() }
+                jsonPath("$.error.code") { value("ROOM_NOT_FOUND") }
+            }
+
+        mockMvc.get("/rooms/share/${payload.shareCode}")
+            .andExpect {
+                status { isNotFound() }
+                jsonPath("$.error.code") { value("INVALID_SHARE_CODE") }
+            }
+    }
+
+    @Test
+    fun `joined member delete request leaves room without deleting host room`() {
+        val hostSession = registerSession("host-delete-forbidden@example.com", "삭제방장2")
+        val payload = createRoomPayload(hostSession)
+        val memberSession = registerSession("member-delete-forbidden@example.com", "삭제멤버")
+
+        mockMvc.post("/rooms/${payload.shareCode}/join") {
+            cookie(memberSession)
+            contentType = MediaType.APPLICATION_JSON
+            content = "{}"
+        }.andExpect {
+            status { isCreated() }
+        }
+        val memberUserId = currentUserId(memberSession)
+        val archiveFixture = createArchiveFixture(payload.roomId, memberUserId)
+
+        mockMvc.delete("/rooms/${payload.roomId}") { cookie(memberSession) }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.roomId") { value(payload.roomId.toInt()) }
+                jsonPath("$.data.deleted") { value(false) }
+                jsonPath("$.data.left") { value(true) }
+            }
+
+        mockMvc.get("/rooms/my") { cookie(memberSession) }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data.rooms.length()") { value(0) }
+            }
+
+        mockMvc.get("/rooms/${payload.roomId}") { cookie(memberSession) }
+            .andExpect {
+                status { isForbidden() }
+                jsonPath("$.error.code") { value("FORBIDDEN") }
+            }
+
+        mockMvc.get("/rooms/${payload.roomId}") { cookie(hostSession) }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data.memberCount") { value(1) }
+            }
+
+        mockMvc.get("/rooms/share/${payload.shareCode}")
+            .andExpect { status { isOk() } }
+
+        val photo = tripPhotoRepository.findById(archiveFixture.photoId).orElseThrow()
+        assertEquals(YnFlag.N, photo.delYn)
+        assertEquals(PhotoStatus.ACTIVE, photo.status)
+        val score = satisfactionScoreRepository.findById(archiveFixture.satisfactionScoreId).orElseThrow()
+        assertEquals(YnFlag.Y, score.delYn)
+    }
+
     private fun assertOAuthRedirectPath(redirectPath: String, expectedLocation: String) {
         val start = mockMvc.get("/auth/google") {
             param("redirectPath", redirectPath)
@@ -373,6 +487,83 @@ class AuthContractTests(
             header { string("Location", expectedLocation) }
         }
     }
+
+    private fun currentUserId(session: jakarta.servlet.http.Cookie): Long {
+        val response = mockMvc.get("/auth/me") { cookie(session) }
+            .andExpect { status { isOk() } }
+            .andReturn().response.contentAsString
+        return Regex("\"id\":(\\d+)").find(response)!!.groupValues[1].toLong()
+    }
+
+    private fun createArchiveFixture(roomId: Long, uploaderUserId: Long): ArchiveFixture {
+        val room = tripRoomRepository.findById(roomId).orElseThrow()
+        room.status = TripRoomStatus.COMPLETED
+        val uploader = userRepository.findById(uploaderUserId).orElseThrow()
+        val place = placeRepository.save(
+            Place(
+                tourApiId = "leave-photo-${System.nanoTime()}",
+                name = "탈퇴 테스트 장소",
+                address = "충청남도 보령시",
+                latitude = BigDecimal("36.5000000"),
+                longitude = BigDecimal("126.5000000"),
+                category = "관광지",
+                mobilityScore = 50,
+                photoScore = 80,
+                budgetScore = 60,
+                themeScore = 40,
+                metadataTags = mapOf("populationDeclineArea" to true),
+            )
+        )
+        val schedule = scheduleRepository.save(
+            Schedule(
+                room = room,
+                version = 1,
+                optionType = ScheduleOptionType.BALANCED,
+                isConfirmed = true,
+                generationInput = mapOf("destination" to room.destination),
+                summary = "탈퇴 테스트 확정 일정",
+                groupSatisfaction = 90,
+            )
+        )
+        val slot = scheduleSlotRepository.save(
+            ScheduleSlot(
+                schedule = schedule,
+                startTime = Instant.parse("2026-06-01T00:00:00Z"),
+                endTime = Instant.parse("2026-06-01T01:00:00Z"),
+                place = place,
+                slotType = SlotType.COMMON,
+                reasonAxis = ReasonAxis.COMMON,
+                reasonText = "탈퇴 테스트 장소",
+                orderIndex = 1,
+            )
+        )
+        val photo = tripPhotoRepository.save(
+            TripPhoto(
+                room = room,
+                schedule = schedule,
+                scheduleSlot = slot,
+                place = place,
+                uploader = uploader,
+                originalFilename = "leave-photo.jpg",
+                contentType = "image/jpeg",
+                fileSize = 1,
+                content = byteArrayOf(1),
+                caption = "탈퇴 후 유지될 사진",
+                status = PhotoStatus.ACTIVE,
+            )
+        )
+        val score = satisfactionScoreRepository.save(
+            SatisfactionScore(
+                schedule = schedule,
+                user = uploader,
+                score = 88,
+                breakdown = mapOf("overall" to 88),
+            )
+        )
+        return ArchiveFixture(photo.id, score.id)
+    }
+
+    private data class ArchiveFixture(val photoId: Long, val satisfactionScoreId: Long)
 
     private fun registerSession(email: String, nickname: String): jakarta.servlet.http.Cookie {
         val uniqueEmail = email.replace("@", "+${System.nanoTime()}@")


### PR DESCRIPTION
## Summary

- 일반 멤버 삭제 요청 시 방 탈퇴 처리
- 방장 삭제 시 기존 방 soft delete 유지

## Changes

- 방장/일반 멤버 DELETE 분기 구현
- 일반 멤버 탈퇴 시 멤버십/프로필/만족도 점수 soft delete
- 탈퇴 멤버 업로드 사진 유지 검증 추가

## Verification

- [ ] Not run
- [x] Build
- [ ] Test
- [ ] Manual

Commands:
- `./gradlew compileKotlin compileTestKotlin`
- `./gradlew test --tests com.tripsync.AuthContractTests`

## Notes

- Testcontainers Docker 미실행으로 통합 테스트 실패: `/var/run/docker.sock` 없음
