### PR TITLE
fix: 일정 생성 LLM 보정 병렬화

### DIFF
--- a/src/main/kotlin/com/tripsync/application/consensus/ConsensusDtos.kt
+++ b/src/main/kotlin/com/tripsync/application/consensus/ConsensusDtos.kt
@@ -91,4 +91,6 @@ data class OptionContext(
     val endTime: String,
     val members: List<MemberSnapshot>,
     val places: List<PlaceCandidate>,
+    val recentPlaceIds: Set<Long> = emptySet(),
+    val diversitySalt: Long = 0L,
 )

--- a/src/main/kotlin/com/tripsync/application/consensus/ConsensusService.kt
+++ b/src/main/kotlin/com/tripsync/application/consensus/ConsensusService.kt
@@ -153,12 +153,14 @@ class ConsensusService(
             avoidPlaceKeysByOrder = usedPlaceKeysByOrder,
         )
 
-        return coroutineScope {
+        val preparedOptions = listOf(balanced, individual, discovery)
+        val refinedOptions = coroutineScope {
             val balancedDeferred = async { refinePreparedOption(balanced, context.members, analysis, context) }
             val individualDeferred = async { refinePreparedOption(individual, context.members, analysis, context) }
             val discoveryDeferred = async { refinePreparedOption(discovery, context.members, analysis, context) }
             listOf(balancedDeferred.await(), individualDeferred.await(), discoveryDeferred.await())
         }
+        return resolveCrossOptionPlaceCollisions(refinedOptions, preparedOptions, context.members)
     }
 
     private fun parseScheduleWindows(tripStartDate: String, tripEndDate: String?, startTime: String, endTime: String): List<ScheduleWindow> {
@@ -684,6 +686,83 @@ class ConsensusService(
             llmLatencyMs = llmAttempt.latencyMs,
             fallbackUsed = llmAttempt.fallbackUsed,
             llmFallbackReason = llmAttempt.fallbackReason?.code,
+        )
+    }
+
+    private fun resolveCrossOptionPlaceCollisions(
+        options: List<ScheduleOptionDraft>,
+        preparedOptions: List<PreparedScheduleOption>,
+        members: List<MemberSnapshot>,
+    ): List<ScheduleOptionDraft> {
+        val usedPlaceIdsByOrder = mutableMapOf<Int, MutableSet<Long>>()
+        val usedPlaceKeysByOrder = mutableMapOf<Int, MutableSet<String>>()
+
+        return options.zip(preparedOptions).map { (option, prepared) ->
+            val placesById = prepared.places.associateBy { it.id }
+            val currentOptionPlaceIds = mutableSetOf<Long>()
+            val currentOptionPlaceKeys = mutableSetOf<String>()
+            val adjustedSlots = option.slots.map { slot ->
+                val slotKeys = scheduleSlotPlaceKeys(slot)
+                val duplicateByOrder = slot.placeId in usedPlaceIdsByOrder[slot.orderIndex].orEmpty() ||
+                    slotKeys.any { it in usedPlaceKeysByOrder[slot.orderIndex].orEmpty() }
+                val duplicateInOption = slot.placeId in currentOptionPlaceIds || slotKeys.any { it in currentOptionPlaceKeys }
+                val adjusted = if (duplicateByOrder || duplicateInOption) {
+                    replacementSlot(slot, prepared, usedPlaceIdsByOrder[slot.orderIndex].orEmpty(), usedPlaceKeysByOrder[slot.orderIndex].orEmpty(), currentOptionPlaceIds, currentOptionPlaceKeys)
+                } else {
+                    slot
+                }
+                currentOptionPlaceIds.add(adjusted.placeId)
+                currentOptionPlaceKeys.addAll(scheduleSlotPlaceKeys(adjusted))
+                usedPlaceIdsByOrder.getOrPut(adjusted.orderIndex) { mutableSetOf() }.add(adjusted.placeId)
+                usedPlaceKeysByOrder.getOrPut(adjusted.orderIndex) { mutableSetOf() }.addAll(scheduleSlotPlaceKeys(adjusted))
+                adjusted
+            }
+
+            val adjustedPlaces = adjustedSlots.mapNotNull { placesById[it.placeId] }
+            if (adjustedPlaces.size != adjustedSlots.size) {
+                option.copy(slots = adjustedSlots)
+            } else {
+                val satisfactionByUser = buildSatisfaction(option.optionType, adjustedSlots, adjustedPlaces, members)
+                option.copy(
+                    slots = adjustedSlots,
+                    satisfactionByUser = satisfactionByUser,
+                    groupSatisfaction = maxOf(prepared.threshold, satisfactionByUser.minOf { it.score }),
+                )
+            }
+        }
+    }
+
+    private fun replacementSlot(
+        slot: ScheduleSlotDraft,
+        prepared: PreparedScheduleOption,
+        usedPlaceIdsForOrder: Set<Long>,
+        usedPlaceKeysForOrder: Set<String>,
+        currentOptionPlaceIds: Set<Long>,
+        currentOptionPlaceKeys: Set<String>,
+    ): ScheduleSlotDraft {
+        val placesById = prepared.places.associateBy { it.id }
+        val shortlistedIds = prepared.shortlistedPerSlot
+            .firstOrNull { it.orderIndex == slot.orderIndex }
+            ?.candidatePlaces
+            ?.map { it.id }
+            .orEmpty()
+        val candidateIds = (shortlistedIds + prepared.slots.map { it.placeId } + prepared.places.map { it.id }).distinct()
+        val replacement = candidateIds
+            .asSequence()
+            .mapNotNull { placesById[it] }
+            .firstOrNull { candidate ->
+                val keys = placeCandidateKeys(candidate)
+                candidate.id !in usedPlaceIdsForOrder &&
+                    candidate.id !in currentOptionPlaceIds &&
+                    keys.none { it in usedPlaceKeysForOrder } &&
+                    keys.none { it in currentOptionPlaceKeys }
+            } ?: return slot
+
+        return slot.copy(
+            placeId = replacement.id,
+            placeName = replacement.name,
+            placeAddress = replacement.address,
+            isHiddenGem = isHiddenGem(replacement),
         )
     }
 

--- a/src/main/kotlin/com/tripsync/application/consensus/ConsensusService.kt
+++ b/src/main/kotlin/com/tripsync/application/consensus/ConsensusService.kt
@@ -570,6 +570,8 @@ class ConsensusService(
                 mustBeHiddenGem = index == forcedHiddenGemIndex,
                 tripDate = tripDate,
                 profile = profile,
+                recentPlaceIds = context.recentPlaceIds,
+                diversitySalt = context.diversitySalt,
             )
             val place = rankedPlaces.firstOrNull()
                 ?: throw DomainException(HttpStatus.UNPROCESSABLE_ENTITY, "PLACE_CANDIDATE_EMPTY", "일정 생성 후보 장소가 부족합니다.")
@@ -745,6 +747,8 @@ class ConsensusService(
         mustBeHiddenGem: Boolean,
         tripDate: String,
         profile: SlotSelectionProfile,
+        recentPlaceIds: Set<Long>,
+        diversitySalt: Long,
     ): List<PlaceCandidate> {
         val source = if (mustBeHiddenGem) places.filter { isHiddenGem(it) } else places
         var pool = if (source.isNotEmpty()) source else places
@@ -793,7 +797,7 @@ class ConsensusService(
         }
 
         return pool.distinctBy { normalizedPlaceName(it) }.sortedByDescending {
-            placeRankingScore(it, targetVector, previousPlace, preferHiddenGem, usedPlaceIds + avoidPlaceIds, tripDate, profile)
+            placeRankingScore(it, targetVector, previousPlace, preferHiddenGem, usedPlaceIds + avoidPlaceIds, recentPlaceIds, tripDate, profile, diversitySalt)
         }
     }
 
@@ -823,11 +827,14 @@ class ConsensusService(
         previousPlace: PlaceCandidate?,
         preferHiddenGem: Boolean,
         usedPlaceIds: Set<Long>,
+        recentPlaceIds: Set<Long>,
         tripDate: String,
         profile: SlotSelectionProfile,
+        diversitySalt: Long,
     ): Double {
         var score = calculateVectorMatch(targetVector, placeScores(place))
         if (usedPlaceIds.contains(place.id)) score -= 0.2
+        if (recentPlaceIds.contains(place.id)) score -= 0.28
         if (previousPlace != null && previousPlace.category == place.category) score -= 0.08
         if (previousPlace != null) {
             val distance = distanceKm(previousPlace, place)
@@ -850,7 +857,15 @@ class ConsensusService(
         }
 
         score += placeCategoryModifier(place, tripDate, profile)
+        score += diversityJitter(place.id, diversitySalt)
         return score
+    }
+
+    private fun diversityJitter(placeId: Long, salt: Long): Double {
+        if (salt == 0L) return 0.0
+        val mixed = placeId * 1103515245L + salt * 12345L
+        val bucket = Math.floorMod(mixed, 1000L)
+        return bucket / 1000.0 * 0.04
     }
 
     private fun distanceKm(from: PlaceCandidate, to: PlaceCandidate): Double? {

--- a/src/main/kotlin/com/tripsync/application/consensus/ConsensusService.kt
+++ b/src/main/kotlin/com/tripsync/application/consensus/ConsensusService.kt
@@ -7,6 +7,8 @@ import com.tripsync.domain.enums.ReasonAxis
 import com.tripsync.domain.enums.ScheduleOptionType
 import com.tripsync.domain.enums.ScoreAxis
 import com.tripsync.domain.enums.SlotType
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
@@ -99,7 +101,7 @@ class ConsensusService(
 
         val usedPlaceIdsByOrder = mutableMapOf<Int, MutableSet<Long>>()
         val usedPlaceKeysByOrder = mutableMapOf<Int, MutableSet<String>>()
-        val balanced = materializeOption(
+        val balanced = prepareOption(
             optionType = ScheduleOptionType.BALANCED,
             label = "균형형",
             summary = "모두가 조금씩 만족하는 안전한 선택",
@@ -117,15 +119,13 @@ class ConsensusService(
             places = optionPlaceScopes.getValue(ScheduleOptionType.BALANCED),
             threshold = 65,
             preferHiddenGem = false,
-            members = context.members,
             tripDate = context.tripDate,
-            analysis = analysis,
             context = context,
             avoidPlaceIdsByOrder = usedPlaceIdsByOrder,
             avoidPlaceKeysByOrder = usedPlaceKeysByOrder,
-        ).also { rememberUsedPlacesByOrder(usedPlaceIdsByOrder, usedPlaceKeysByOrder, it) }
+        ).also { rememberUsedPlacesByOrder(usedPlaceIdsByOrder, usedPlaceKeysByOrder, it.slots) }
 
-        val individual = materializeOption(
+        val individual = prepareOption(
             optionType = ScheduleOptionType.INDIVIDUAL,
             label = "개성형",
             summary = "각자의 취향이 살아있는 교대 배분 일정",
@@ -133,15 +133,13 @@ class ConsensusService(
             places = optionPlaceScopes.getValue(ScheduleOptionType.INDIVIDUAL),
             threshold = 60,
             preferHiddenGem = false,
-            members = context.members,
             tripDate = context.tripDate,
-            analysis = analysis,
             context = context,
             avoidPlaceIdsByOrder = usedPlaceIdsByOrder,
             avoidPlaceKeysByOrder = usedPlaceKeysByOrder,
-        ).also { rememberUsedPlacesByOrder(usedPlaceIdsByOrder, usedPlaceKeysByOrder, it) }
+        ).also { rememberUsedPlacesByOrder(usedPlaceIdsByOrder, usedPlaceKeysByOrder, it.slots) }
 
-        val discovery = materializeOption(
+        val discovery = prepareOption(
             optionType = ScheduleOptionType.DISCOVERY,
             label = "지역 발굴형",
             summary = "${destinationLabel(context.destination)} 숨은 명소 중심 탐험 일정",
@@ -149,15 +147,18 @@ class ConsensusService(
             places = optionPlaceScopes.getValue(ScheduleOptionType.DISCOVERY),
             threshold = 55,
             preferHiddenGem = true,
-            members = context.members,
             tripDate = context.tripDate,
-            analysis = analysis,
             context = context,
             avoidPlaceIdsByOrder = usedPlaceIdsByOrder,
             avoidPlaceKeysByOrder = usedPlaceKeysByOrder,
         )
 
-        return listOf(balanced, individual, discovery)
+        return coroutineScope {
+            val balancedDeferred = async { refinePreparedOption(balanced, context.members, analysis, context) }
+            val individualDeferred = async { refinePreparedOption(individual, context.members, analysis, context) }
+            val discoveryDeferred = async { refinePreparedOption(discovery, context.members, analysis, context) }
+            listOf(balancedDeferred.await(), individualDeferred.await(), discoveryDeferred.await())
+        }
     }
 
     private fun parseScheduleWindows(tripStartDate: String, tripEndDate: String?, startTime: String, endTime: String): List<ScheduleWindow> {
@@ -534,7 +535,7 @@ class ConsensusService(
         )
     }
 
-    private suspend fun materializeOption(
+    private fun prepareOption(
         optionType: ScheduleOptionType,
         label: String,
         summary: String,
@@ -542,13 +543,11 @@ class ConsensusService(
         places: List<PlaceCandidate>,
         threshold: Int,
         preferHiddenGem: Boolean,
-        members: List<MemberSnapshot>,
         tripDate: String,
-        analysis: GroupAnalysis,
         context: OptionContext,
         avoidPlaceIdsByOrder: Map<Int, Set<Long>>,
         avoidPlaceKeysByOrder: Map<Int, Set<String>>,
-    ): ScheduleOptionDraft {
+    ): PreparedScheduleOption {
         val chosenPlaces = mutableListOf<PlaceCandidate>()
         val forcedHiddenGemIndex = if (preferHiddenGem) pickForcedHiddenGemSlot(targets) else -1
         val shortlistedPerSlot = mutableListOf<SlotShortlist>()
@@ -608,27 +607,45 @@ class ConsensusService(
             )
         }
 
-        val llmAttempt = llmService.refineScheduleOption(
+        return PreparedScheduleOption(
             optionType = optionType,
             label = label,
             summary = summary,
+            threshold = threshold,
+            places = places,
+            slots = slots,
+            chosenPlaces = chosenPlaces,
+            shortlistedPerSlot = shortlistedPerSlot,
+        )
+    }
+
+    private suspend fun refinePreparedOption(
+        prepared: PreparedScheduleOption,
+        members: List<MemberSnapshot>,
+        analysis: GroupAnalysis,
+        context: OptionContext,
+    ): ScheduleOptionDraft {
+        val llmAttempt = llmService.refineScheduleOption(
+            optionType = prepared.optionType,
+            label = prepared.label,
+            summary = prepared.summary,
             room = RoomRef(roomId = context.roomId, destination = context.destination, tripDate = context.tripDate),
             commonAxes = analysis.commonAxes,
             priorityAxes = analysis.priorityAxes,
             members = members.map { MemberRef(it.userId, it.nickname) },
-            slotPlan = shortlistedPerSlot,
+            slotPlan = prepared.shortlistedPerSlot,
         )
         val llmRefined = llmAttempt.result
 
-        val finalSummary = llmRefined?.summary ?: summary
-        val placesById = places.associateBy { it.id }
+        val finalSummary = llmRefined?.summary ?: prepared.summary
+        val placesById = prepared.places.associateBy { it.id }
         val finalPlacesByOrder = mutableMapOf<Int, PlaceCandidate>()
         llmRefined?.slots?.forEach { slot ->
             placesById[slot.placeId]?.let { finalPlacesByOrder[slot.orderIndex] = it }
         }
 
         val refinedByOrder = llmRefined?.slots?.associateBy { it.orderIndex } ?: emptyMap()
-        val finalSlots = slots.map { slot ->
+        val finalSlots = prepared.slots.map { slot ->
             val refined = refinedByOrder[slot.orderIndex]
             val refinedPlace = refined?.let { finalPlacesByOrder[it.orderIndex] }
             if (refined == null || refinedPlace == null) {
@@ -645,19 +662,19 @@ class ConsensusService(
         }
 
         val finalPlaces = finalSlots.mapIndexed { index, slot ->
-            finalPlacesByOrder[slot.orderIndex] ?: chosenPlaces[index]
+            finalPlacesByOrder[slot.orderIndex] ?: prepared.chosenPlaces[index]
         }
 
-        val satisfactionByUser = buildSatisfaction(optionType, finalSlots, finalPlaces, members)
-        val groupSatisfaction = maxOf(threshold, satisfactionByUser.minOf { it.score })
+        val satisfactionByUser = buildSatisfaction(prepared.optionType, finalSlots, finalPlaces, members)
+        val groupSatisfaction = maxOf(prepared.threshold, satisfactionByUser.minOf { it.score })
 
         logger.info {
-            "schedule_option optionType=$optionType roomId=${context.roomId} provider=${llmRefined?.provider ?: DETERMINISTIC_PROVIDER} attemptedProvider=${llmAttempt.attemptedProvider} latencyMs=${llmAttempt.latencyMs ?: 0} fallbackUsed=${llmAttempt.fallbackUsed} fallbackReason=${llmAttempt.fallbackReason?.code ?: "none"} groupSatisfaction=$groupSatisfaction"
+            "schedule_option optionType=${prepared.optionType} roomId=${context.roomId} provider=${llmRefined?.provider ?: DETERMINISTIC_PROVIDER} attemptedProvider=${llmAttempt.attemptedProvider} latencyMs=${llmAttempt.latencyMs ?: 0} fallbackUsed=${llmAttempt.fallbackUsed} fallbackReason=${llmAttempt.fallbackReason?.code ?: "none"} groupSatisfaction=$groupSatisfaction"
         }
 
         return ScheduleOptionDraft(
-            optionType = optionType,
-            label = label,
+            optionType = prepared.optionType,
+            label = prepared.label,
             summary = finalSummary,
             groupSatisfaction = groupSatisfaction,
             slots = finalSlots,
@@ -670,12 +687,23 @@ class ConsensusService(
         )
     }
 
+    private data class PreparedScheduleOption(
+        val optionType: ScheduleOptionType,
+        val label: String,
+        val summary: String,
+        val threshold: Int,
+        val places: List<PlaceCandidate>,
+        val slots: List<ScheduleSlotDraft>,
+        val chosenPlaces: List<PlaceCandidate>,
+        val shortlistedPerSlot: List<SlotShortlist>,
+    )
+
     private fun rememberUsedPlacesByOrder(
         usedPlaceIdsByOrder: MutableMap<Int, MutableSet<Long>>,
         usedPlaceKeysByOrder: MutableMap<Int, MutableSet<String>>,
-        option: ScheduleOptionDraft,
+        slots: List<ScheduleSlotDraft>,
     ) {
-        option.slots.forEach { slot ->
+        slots.forEach { slot ->
             usedPlaceIdsByOrder.getOrPut(slot.orderIndex) { mutableSetOf() }.add(slot.placeId)
             usedPlaceKeysByOrder.getOrPut(slot.orderIndex) { mutableSetOf() }.addAll(scheduleSlotPlaceKeys(slot))
         }

--- a/src/main/kotlin/com/tripsync/application/consensus/LlmService.kt
+++ b/src/main/kotlin/com/tripsync/application/consensus/LlmService.kt
@@ -5,7 +5,7 @@ import com.tripsync.infrastructure.llm.OpenAiClient
 import org.springframework.stereotype.Service
 
 @Service
-class LlmService(
+open class LlmService(
     private val openAiClient: OpenAiClient,
 ) {
 
@@ -39,7 +39,7 @@ class LlmService(
         val failureDetail: String? = null,
     )
 
-    suspend fun refineScheduleOption(
+    open suspend fun refineScheduleOption(
         optionType: ScheduleOptionType,
         label: String,
         summary: String,

--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleGenerationPersistenceService.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleGenerationPersistenceService.kt
@@ -4,6 +4,7 @@ import com.tripsync.domain.entity.AxisScores
 import com.tripsync.application.consensus.MemberSnapshot
 import com.tripsync.application.consensus.PlaceCandidate
 import com.tripsync.application.consensus.ScheduleOptionDraft
+import com.tripsync.application.consensus.ScheduleSlotDraft
 import com.tripsync.common.exception.DomainException
 import com.tripsync.domain.entity.Place
 import com.tripsync.domain.entity.SatisfactionScore
@@ -105,7 +106,9 @@ class ScheduleGenerationPersistenceService(
         val room = tripRoomRepository.findActiveByIdForUpdate(roomId, YnFlag.N)
             ?: throw DomainException(HttpStatus.NOT_FOUND, "ROOM_NOT_FOUND", "존재하지 않는 방입니다.")
         val version = (scheduleRepository.findTopByRoomIdAndDelYnOrderByVersionDesc(room.id, YnFlag.N)?.version ?: 0) + 1
-        val saved = options.map { option ->
+        val replacementCandidates = placeQueryRepository.findScheduleCandidates(dto.destination)
+        val saved = options.map { rawOption ->
+            val option = rawOption.copy(slots = ensureUniqueSlots(rawOption.slots, replacementCandidates))
             val personaValidation = personaValidationByType[option.optionType]
             val schedule = scheduleRepository.save(
                 Schedule(
@@ -180,6 +183,56 @@ class ScheduleGenerationPersistenceService(
         }
         return SavedScheduleGeneration(version = version, options = saved)
     }
+    private fun ensureUniqueSlots(slots: List<ScheduleSlotDraft>, replacementCandidates: List<Place>): List<ScheduleSlotDraft> {
+        if (slots.isEmpty()) return slots
+
+        val candidates = replacementCandidates
+            .filter { it.delYn == YnFlag.N }
+            .distinctBy { it.id }
+        val usedPlaceIds = mutableSetOf<Long>()
+        val usedPlaceKeys = mutableSetOf<String>()
+
+        return slots.map { slot ->
+            val slotKeys = placeKeys(slot.placeName, slot.placeAddress)
+            val isDuplicate = slot.placeId in usedPlaceIds || slotKeys.any { it in usedPlaceKeys }
+            val uniqueSlot = if (isDuplicate) {
+                candidates.firstOrNull { candidate ->
+                    candidate.id !in usedPlaceIds && placeKeys(candidate.name, candidate.address).none { it in usedPlaceKeys }
+                }?.let { replacement ->
+                    slot.copy(
+                        placeId = replacement.id,
+                        placeName = replacement.name,
+                        placeAddress = replacement.address,
+                        isHiddenGem = isHiddenGem(replacement),
+                    )
+                } ?: slot
+            } else {
+                slot
+            }
+
+            usedPlaceIds.add(uniqueSlot.placeId)
+            usedPlaceKeys.addAll(placeKeys(uniqueSlot.placeName, uniqueSlot.placeAddress))
+            uniqueSlot
+        }
+    }
+
+    private fun isHiddenGem(place: Place): Boolean {
+        return place.metadataTags?.get("hiddenGem") == true ||
+            place.metadataTags?.get("populationDeclineArea") == true ||
+            place.metadataTags?.get("regionalBenefit") == true ||
+            place.metadataTags?.get("regionType") == "population_decline"
+    }
+
+    private fun placeKeys(name: String, address: String): Set<String> {
+        val normalizedName = normalizePlaceText(name)
+        val normalizedAddress = normalizePlaceText(address)
+        return setOf(normalizedName, "$normalizedName|$normalizedAddress").filter { it.isNotBlank() }.toSet()
+    }
+
+    private fun normalizePlaceText(value: String): String {
+        return value.trim().lowercase().replace(Regex("[\\s\\p{Punct}]+"), "")
+    }
+
 
     @Transactional(readOnly = true)
     fun getRoomIdForRegeneration(scheduleId: Long, userId: Long): Long {

--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleService.kt
@@ -38,6 +38,7 @@ class ScheduleService(
         val members = generationContext.members
         val placesById = generationContext.placesById
 
+        val recentPlaceIds = latestGeneratedPlaceIds(roomId)
         val context = OptionContext(
             roomId = roomId,
             destination = dto.destination,
@@ -47,6 +48,8 @@ class ScheduleService(
             endTime = dto.endTime,
             members = members,
             places = generationContext.places,
+            recentPlaceIds = recentPlaceIds,
+            diversitySalt = System.nanoTime(),
         )
 
         val options = runBlocking { consensusService.buildScheduleOptions(context) }
@@ -74,6 +77,16 @@ class ScheduleService(
                 },
             )
         )
+    }
+
+
+    private fun latestGeneratedPlaceIds(roomId: Long): Set<Long> {
+        val schedules = scheduleRepository.findByRoomIdAndDelYn(roomId, YnFlag.N)
+        val latestVersion = schedules.maxOfOrNull { it.version } ?: return emptySet()
+        return schedules
+            .filter { it.version == latestVersion }
+            .flatMap { scheduleSlotRepository.findActivePlaceIdsByScheduleId(it.id, YnFlag.N) }
+            .toSet()
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/tripsync/infrastructure/llm/OpenAiClient.kt
+++ b/src/main/kotlin/com/tripsync/infrastructure/llm/OpenAiClient.kt
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @Component
@@ -26,6 +27,8 @@ class OpenAiClient(
     private val apiKey: String,
     @Value("\${openai.model:gpt-4o-mini}")
     private val model: String,
+    @Value("\${openai.timeout-seconds:10}")
+    private val timeoutSeconds: Long = 10,
     private val meterRegistry: MeterRegistry,
 ) {
     private val logger = KotlinLogging.logger {}
@@ -77,6 +80,7 @@ class OpenAiClient(
                 .bodyValue(requestBody)
                 .retrieve()
                 .bodyToMono<String>()
+                .timeout(Duration.ofSeconds(timeoutSeconds.coerceAtLeast(1)))
                 .awaitSingle()
 
             val latencyMs = elapsedMillis(startNanos)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -64,6 +64,7 @@ jwt:
 openai:
   api-key: ${OPENAI_API_KEY:}
   model: ${OPENAI_MODEL:gpt-4o-mini}
+  timeout-seconds: ${OPENAI_TIMEOUT_SECONDS:10}
 
 tourapi:
   key: ${TOURAPI_KEY:${TOUR_API_SERVICE_KEY:}}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,7 @@ jwt:
 openai:
   api-key: ${OPENAI_API_KEY:}
   model: ${OPENAI_MODEL:gpt-4o-mini}
+  timeout-seconds: ${OPENAI_TIMEOUT_SECONDS:10}
 
 tourapi:
   key: ${TOURAPI_KEY:${TOUR_API_SERVICE_KEY:}}

--- a/src/test/kotlin/com/tripsync/application/consensus/ConsensusServiceTest.kt
+++ b/src/test/kotlin/com/tripsync/application/consensus/ConsensusServiceTest.kt
@@ -10,7 +10,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import java.time.Duration
 import java.time.ZoneId
 
 class ConsensusServiceTest {
@@ -52,6 +56,44 @@ class ConsensusServiceTest {
             assertTrue(option.fallbackUsed)
             assertEquals("api_key_missing", option.llmFallbackReason)
         }
+    }
+
+    @Test
+    fun `llm refinement runs recommendation options in parallel`() = runBlocking {
+        val slowWebClient = WebClient.builder()
+            .exchangeFunction {
+                Mono.delay(Duration.ofSeconds(3))
+                    .thenReturn(ClientResponse.create(HttpStatus.OK).body("{}").build())
+            }
+            .build()
+        val parallelConsensusService = ConsensusService(
+            LlmService(
+                OpenAiClient(
+                    webClient = slowWebClient,
+                    objectMapper = ObjectMapper(),
+                    apiKey = "test-key",
+                    model = "gpt-test",
+                    timeoutSeconds = 1,
+                    meterRegistry = SimpleMeterRegistry(),
+                )
+            )
+        )
+
+        val startNanos = System.nanoTime()
+        val options = parallelConsensusService.buildScheduleOptions(
+            context(
+                destination = "공주시",
+                startTime = "09:00",
+                endTime = "12:00",
+                members = members(2),
+                places = places("충청남도 공주시"),
+            )
+        )
+        val elapsedMillis = Duration.ofNanos(System.nanoTime() - startNanos).toMillis()
+
+        assertEquals(3, options.size)
+        assertTrue(options.all { it.fallbackUsed })
+        assertTrue(elapsedMillis < 2_500, "three LLM refinements should wait once in parallel instead of timing out sequentially")
     }
 
     @Test

--- a/src/test/kotlin/com/tripsync/application/consensus/ConsensusServiceTest.kt
+++ b/src/test/kotlin/com/tripsync/application/consensus/ConsensusServiceTest.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.tripsync.common.exception.DomainException
 import com.tripsync.domain.entity.AxisScores
+import com.tripsync.domain.enums.ScheduleOptionType
 import com.tripsync.infrastructure.llm.OpenAiClient
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -94,6 +96,37 @@ class ConsensusServiceTest {
         assertEquals(3, options.size)
         assertTrue(options.all { it.fallbackUsed })
         assertTrue(elapsedMillis < 2_500, "three LLM refinements should wait once in parallel instead of timing out sequentially")
+    }
+
+    @Test
+    fun `llm refined places are deduplicated across recommendation options by same order`() = runBlocking {
+        val llmConsensusService = ConsensusService(coordinatedDuplicateLlmService())
+
+        val options = llmConsensusService.buildScheduleOptions(
+            context(
+                destination = "공주시",
+                startTime = "09:00",
+                endTime = "12:00",
+                members = members(2),
+                places = places("충청남도 공주시"),
+            )
+        )
+
+        assertEquals(3, options.size)
+        assertTrue(options.all { it.llmProvider == "test/duplicate-llm" }, "test must exercise successful LLM-refined slots before deduplication")
+        val slotsByOrder = options.flatMap { it.slots }.groupBy { it.orderIndex }
+        slotsByOrder.forEach { (orderIndex, slots) ->
+            assertEquals(
+                slots.size,
+                slots.map { it.placeId }.toSet().size,
+                "slot $orderIndex repeated the same LLM-refined place across recommendation options",
+            )
+            assertEquals(
+                slots.size,
+                slots.map { normalizePlaceName(it.placeName) }.toSet().size,
+                "slot $orderIndex repeated the same LLM-refined visible place across recommendation options",
+            )
+        }
     }
 
     @Test
@@ -289,6 +322,66 @@ class ConsensusServiceTest {
         }
 
         assertEquals("PLACE_CANDIDATE_EMPTY", error.code)
+    }
+
+    private fun coordinatedDuplicateLlmService(): LlmService {
+        val client = OpenAiClient(
+            webClient = WebClient.create(),
+            objectMapper = ObjectMapper(),
+            apiKey = "",
+            model = "gpt-test",
+            meterRegistry = SimpleMeterRegistry(),
+        )
+        return object : LlmService(client) {
+            private val lock = Any()
+            private val requests = mutableListOf<Pair<ScheduleOptionType, List<ConsensusService.SlotShortlist>>>()
+            private val ready = CompletableDeferred<Map<Int, Long>>()
+
+            override suspend fun refineScheduleOption(
+                optionType: ScheduleOptionType,
+                label: String,
+                summary: String,
+                room: ConsensusService.RoomRef,
+                commonAxes: List<com.tripsync.domain.enums.ScoreAxis>,
+                priorityAxes: List<com.tripsync.domain.enums.ScoreAxis>,
+                members: List<ConsensusService.MemberRef>,
+                slotPlan: List<ConsensusService.SlotShortlist>,
+            ): RefinementAttempt {
+                synchronized(lock) {
+                    requests.add(optionType to slotPlan)
+                    if (requests.size == 3 && !ready.isCompleted) {
+                        val sharedPlaceByOrder = slotPlan.map { it.orderIndex }.associateWith { orderIndex ->
+                            val candidateSets = requests.map { (_, plan) ->
+                                plan.first { it.orderIndex == orderIndex }.candidatePlaces.map { candidate -> candidate.id }.toSet()
+                            }
+                            candidateSets.reduce { acc, ids -> acc.intersect(ids) }.firstOrNull()
+                                ?: candidateSets.first().first()
+                        }
+                        ready.complete(sharedPlaceByOrder)
+                    }
+                }
+                val sharedPlaceByOrder = ready.await()
+                val refinedSlots = slotPlan.map { slot ->
+                    RefinedSlot(
+                        orderIndex = slot.orderIndex,
+                        placeId = sharedPlaceByOrder.getValue(slot.orderIndex),
+                        reason = "LLM 중복 선택",
+                    )
+                }
+                return RefinementAttempt(
+                    result = RefinementResult(
+                        summary = "LLM 보정 요약",
+                        provider = "test/duplicate-llm",
+                        latencyMs = 1,
+                        slots = refinedSlots,
+                    ),
+                    attemptedProvider = "test/duplicate-llm",
+                    latencyMs = 1,
+                    fallbackUsed = false,
+                    fallbackReason = null,
+                )
+            }
+        }
     }
 
     private fun context(

--- a/src/test/kotlin/com/tripsync/application/schedule/ScheduleServiceTest.kt
+++ b/src/test/kotlin/com/tripsync/application/schedule/ScheduleServiceTest.kt
@@ -135,6 +135,36 @@ class ScheduleServiceTest(
     }
 
     @Test
+    fun `generated schedule save replaces duplicated places before persistence`() {
+        val fixture = createFixture(isConfirmed = false)
+        val dto = GenerateScheduleDto(
+            destination = "충남",
+            tripDate = "2026-06-01",
+            startTime = "09:00",
+            endTime = "12:00",
+        )
+
+        val saved = generationPersistenceService.saveGeneratedOptions(
+            roomId = fixture.schedule.room.id,
+            dto = dto,
+            options = listOf(duplicatedGeneratedOption(fixture.host.id, fixture.newPlace.id)),
+            personaValidationByType = emptyMap(),
+        )
+
+        val persistedSlots = scheduleSlotRepository.findAll()
+            .filter { it.schedule.id == saved.options.first().scheduleId }
+            .sortedBy { it.orderIndex }
+
+        assertEquals(2, persistedSlots.size)
+        assertEquals(2, persistedSlots.map { it.place.id }.toSet().size)
+        assertEquals(
+            2,
+            persistedSlots.map { normalizePlaceName(it.place.name) }.toSet().size,
+            "schedule save must not persist repeated visible place names",
+        )
+    }
+
+    @Test
     fun `concurrent generated schedule saves allocate different versions`() {
         val fixture = createFixture(isConfirmed = false)
         val workers = 4
@@ -278,6 +308,44 @@ class ScheduleServiceTest(
             fallbackUsed = true,
             llmFallbackReason = "test",
         )
+    }
+
+    private fun duplicatedGeneratedOption(userId: Long, placeId: Long): ScheduleOptionDraft {
+        val start = Instant.parse("2026-06-01T00:00:00Z")
+        return generatedOption(userId, placeId).copy(
+            slots = listOf(
+                ScheduleSlotDraft(
+                    orderIndex = 1,
+                    slotType = SlotType.COMMON,
+                    targetUserId = null,
+                    reasonAxis = ReasonAxis.COMMON,
+                    reasonText = "첫 장소",
+                    startTime = start,
+                    endTime = start.plusSeconds(3600),
+                    placeId = placeId,
+                    placeName = "태안 안면도 꽃지해수욕장",
+                    placeAddress = "충청남도 태안군 안면읍 승언리",
+                    isHiddenGem = false,
+                ),
+                ScheduleSlotDraft(
+                    orderIndex = 2,
+                    slotType = SlotType.COMMON,
+                    targetUserId = null,
+                    reasonAxis = ReasonAxis.COMMON,
+                    reasonText = "중복 장소",
+                    startTime = start.plusSeconds(3600),
+                    endTime = start.plusSeconds(7200),
+                    placeId = placeId,
+                    placeName = "태안 안면도 꽃지해수욕장",
+                    placeAddress = "충청남도 태안군 안면읍 승언리",
+                    isHiddenGem = false,
+                ),
+            ),
+        )
+    }
+
+    private fun normalizePlaceName(name: String): String {
+        return name.trim().lowercase().replace(Regex("[\\s\\p{Punct}]+"), "")
     }
 
     private fun place(tourApiId: String, name: String, address: String): Place {

--- a/src/test/kotlin/com/tripsync/infrastructure/llm/OpenAiClientTest.kt
+++ b/src/test/kotlin/com/tripsync/infrastructure/llm/OpenAiClientTest.kt
@@ -10,7 +10,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import java.time.Duration
 
 class OpenAiClientTest {
     private val client = OpenAiClient(
@@ -52,6 +56,41 @@ class OpenAiClientTest {
             "outcome", "fallback",
             "reason", "api_key_missing",
         ).count())
+    }
+
+    @Test
+    fun `refine schedule falls back quickly when openai call exceeds configured timeout`() = runBlocking {
+        val slowWebClient = WebClient.builder()
+            .exchangeFunction {
+                Mono.delay(Duration.ofSeconds(3))
+                    .thenReturn(ClientResponse.create(HttpStatus.OK).body("{}").build())
+            }
+            .build()
+        val timeoutClient = OpenAiClient(
+            webClient = slowWebClient,
+            objectMapper = ObjectMapper(),
+            apiKey = "test-key",
+            model = "gpt-test",
+            timeoutSeconds = 1,
+            meterRegistry = SimpleMeterRegistry(),
+        )
+
+        val startNanos = System.nanoTime()
+        val attempt = timeoutClient.refineSchedule(
+            optionType = ScheduleOptionType.BALANCED,
+            label = "균형형",
+            summary = "요약",
+            room = ConsensusService.RoomRef(roomId = 1, destination = "충남", tripDate = "2026-06-01"),
+            commonAxes = emptyList(),
+            priorityAxes = emptyList(),
+            members = emptyList(),
+            slotPlan = emptyList(),
+        )
+        val elapsedMillis = Duration.ofNanos(System.nanoTime() - startNanos).toMillis()
+
+        assertTrue(attempt.fallbackUsed)
+        assertEquals(LlmService.FallbackReason.API_CALL_FAILED, attempt.fallbackReason)
+        assertTrue(elapsedMillis < 2_500, "OpenAI timeout fallback should happen near the configured timeout")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- 일정 생성 타임아웃 및 추천 옵션 중복 방지

## Changes

- OpenAI 일정 보정 호출 10초 timeout 적용
- 3개 추천 옵션 LLM 보정 병렬 실행
- LLM 지연/실패 시 옵션별 deterministic fallback 유지
- LLM 보정 후 order별 옵션 간 장소 중복 후처리 추가
- 병렬 보정, timeout fallback, LLM 보정 후 중복 방지 회귀 테스트 추가

## Verification

- [ ] Not run
- [ ] Build
- [x] Test
  - `./gradlew test --tests 'com.tripsync.infrastructure.llm.OpenAiClientTest' --tests 'com.tripsync.application.consensus.ConsensusServiceTest' --tests 'com.tripsync.application.schedule.ScheduleServiceTest' --no-daemon --max-workers=1`
- [x] Manual
  - `docker compose up -d --build server`
  - `tripsync-server health=healthy`

## Notes

-
