### PR TITLE
Refactor: OAuth 응답 및 LLM 메타데이터 정리

### DIFF
--- a/src/main/kotlin/com/tripsync/application/auth/OAuth2UserService.kt
+++ b/src/main/kotlin/com/tripsync/application/auth/OAuth2UserService.kt
@@ -4,12 +4,9 @@ import com.tripsync.common.dto.ApiResponse
 import com.tripsync.common.exception.DomainException
 import com.tripsync.domain.entity.User
 import com.tripsync.domain.enums.AuthProvider
-import com.tripsync.domain.enums.YnFlag
 import com.tripsync.domain.repository.UserRepository
-import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 
@@ -18,8 +15,6 @@ class OAuth2UserService(
     private val userRepository: UserRepository,
     private val jwtTokenProvider: JwtTokenProvider,
 ) : DefaultOAuth2UserService() {
-    private val logger = KotlinLogging.logger {}
-
     fun processGoogleLogin(oAuth2User: OAuth2User): ApiResponse<Map<String, Any>> {
         val email = oAuth2User.getAttribute<String>("email")
             ?: throw DomainException(HttpStatus.BAD_REQUEST, "OAUTH_EMAIL_MISSING", "이메일 정보를 가져올 수 없습니다.")
@@ -28,33 +23,14 @@ class OAuth2UserService(
         val providerId = oAuth2User.getAttribute<String>("sub")
             ?: throw DomainException(HttpStatus.BAD_REQUEST, "OAUTH_ID_MISSING", "사용자 ID를 가져올 수 없습니다.")
 
-        val existingUser = userRepository.findByAuthProviderAndProviderUserId(AuthProvider.GOOGLE, providerId)
-
-        val user = if (existingUser != null) {
-            existingUser
-        } else {
-            userRepository.save(
-                User(
-                    nickname = name,
-                    email = email,
-                    authProvider = AuthProvider.GOOGLE,
-                    providerUserId = providerId,
-                    profileImageUrl = picture,
-                )
-            )
-        }
-
-        val token = jwtTokenProvider.generateToken(user.id, user.isGuest)
-        @Suppress("UNCHECKED_CAST")
-        return ApiResponse.ok(
-            mapOf(
-                "token" to token,
-                "userId" to user.id,
-                "nickname" to user.nickname,
-                "email" to (user.email ?: ""),
-                "authProvider" to user.authProvider.name,
-            ) as Map<String, Any>
+        val user = findOrCreateOAuthUser(
+            provider = AuthProvider.GOOGLE,
+            providerId = providerId,
+            nickname = name,
+            email = email,
+            profileImageUrl = picture,
         )
+        return authResponse(user)
     }
 
     fun processKakaoLogin(oAuth2User: OAuth2User): ApiResponse<Map<String, Any>> {
@@ -68,24 +44,37 @@ class OAuth2UserService(
         val providerId = attributes["id"]?.toString()
             ?: throw DomainException(HttpStatus.BAD_REQUEST, "OAUTH_ID_MISSING", "사용자 ID를 가져올 수 없습니다.")
 
-        val existingUser = userRepository.findByAuthProviderAndProviderUserId(AuthProvider.KAKAO, providerId)
+        val user = findOrCreateOAuthUser(
+            provider = AuthProvider.KAKAO,
+            providerId = providerId,
+            nickname = nickname,
+            email = email,
+            profileImageUrl = profileImage,
+        )
+        return authResponse(user)
+    }
 
-        val user = if (existingUser != null) {
-            existingUser
-        } else {
-            userRepository.save(
+    private fun findOrCreateOAuthUser(
+        provider: AuthProvider,
+        providerId: String,
+        nickname: String,
+        email: String?,
+        profileImageUrl: String?,
+    ): User {
+        return userRepository.findByAuthProviderAndProviderUserId(provider, providerId)
+            ?: userRepository.save(
                 User(
                     nickname = nickname,
                     email = email,
-                    authProvider = AuthProvider.KAKAO,
+                    authProvider = provider,
                     providerUserId = providerId,
-                    profileImageUrl = profileImage,
+                    profileImageUrl = profileImageUrl,
                 )
             )
-        }
+    }
 
+    private fun authResponse(user: User): ApiResponse<Map<String, Any>> {
         val token = jwtTokenProvider.generateToken(user.id, user.isGuest)
-        @Suppress("UNCHECKED_CAST")
         return ApiResponse.ok(
             mapOf(
                 "token" to token,
@@ -93,7 +82,7 @@ class OAuth2UserService(
                 "nickname" to user.nickname,
                 "email" to (user.email ?: ""),
                 "authProvider" to user.authProvider.name,
-            ) as Map<String, Any>
+            )
         )
     }
 }

--- a/src/main/kotlin/com/tripsync/application/schedule/ScheduleResponseMapper.kt
+++ b/src/main/kotlin/com/tripsync/application/schedule/ScheduleResponseMapper.kt
@@ -139,9 +139,8 @@ class ScheduleResponseMapper(
         return formatStoredSchedule(schedule).filterKeys { it in publicKeys }
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun formatLlmMetadata(schedule: Schedule): Map<String, Any?> {
-        val metadata = schedule.generationInput["llm"] as? Map<String, Any?> ?: emptyMap()
+        val metadata = schedule.generationInput["llm"] as? Map<*, *> ?: emptyMap<String, Any?>()
         val provider = schedule.llmProvider ?: metadata["provider"]
         return mapOf(
             "provider" to provider,


### PR DESCRIPTION
## Summary

- 백엔드 OAuth/일정 응답 매퍼 정리

## Changes

- Google/Kakao OAuth 사용자 조회·생성 로직 공통화
- OAuth 인증 응답 payload 생성 로직 공통화
- 일정 LLM 메타데이터 unchecked cast suppression 제거

## Verification

- [ ] Not run
- [ ] Build
- [x] Test
  - `./gradlew test`
  - `./gradlew test --tests com.tripsync.AuthContractTests`
  - `./gradlew test --tests com.tripsync.application.schedule.ScheduleResponseMapperTest --tests com.tripsync.AuthContractTests`
  - `./gradlew check`
- [ ] Manual

## Notes

-
